### PR TITLE
Fix ACF value warnings on answer processing page

### DIFF
--- a/inc/enigme-functions.php
+++ b/inc/enigme-functions.php
@@ -766,15 +766,24 @@ function envoyer_mail_notification_joueur($user_id, $enigme_id, $resultat) {
     $headers = [
         'Content-Type: text/html; charset=UTF-8'
     ];
-    $chasse_id = get_field('enigme_chasse_associee', $enigme_id, false);
-$organisateur_id = get_organisateur_from_chasse($chasse_id);
-$email_organisateur = get_field('email_organisateur', $organisateur_id);
+    $chasse_raw = get_field('enigme_chasse_associee', $enigme_id, false);
+    if (is_array($chasse_raw)) {
+        $first     = reset($chasse_raw);
+        $chasse_id = is_object($first) ? (int) $first->ID : (int) $first;
+    } elseif (is_object($chasse_raw)) {
+        $chasse_id = (int) $chasse_raw->ID;
+    } else {
+        $chasse_id = (int) $chasse_raw;
+    }
 
-if (!is_email($email_organisateur)) {
-    $email_organisateur = get_option('admin_email');
-}
+    $organisateur_id    = $chasse_id ? get_organisateur_from_chasse($chasse_id) : null;
+    $email_organisateur = $organisateur_id ? get_field('email_organisateur', $organisateur_id) : '';
 
-$headers[] = 'Reply-To: ' . $email_organisateur;
+    if (!is_email($email_organisateur)) {
+        $email_organisateur = get_option('admin_email');
+    }
+
+    $headers[] = 'Reply-To: ' . $email_organisateur;
 
 wp_mail($user->user_email, $sujet, $message, $headers);
 }
@@ -805,9 +814,18 @@ function envoyer_mail_accuse_reception_joueur($user_id, $enigme_id)
     $message .= '</div>';
 
     // Reply-to = organisateur
-    $chasse_id = get_field('enigme_chasse_associee', $enigme_id, false);
-    $organisateur_id = get_organisateur_from_chasse($chasse_id);
-    $email_organisateur = get_field('email_organisateur', $organisateur_id);
+    $chasse_raw = get_field('enigme_chasse_associee', $enigme_id, false);
+    if (is_array($chasse_raw)) {
+        $first     = reset($chasse_raw);
+        $chasse_id = is_object($first) ? (int) $first->ID : (int) $first;
+    } elseif (is_object($chasse_raw)) {
+        $chasse_id = (int) $chasse_raw->ID;
+    } else {
+        $chasse_id = (int) $chasse_raw;
+    }
+
+    $organisateur_id    = $chasse_id ? get_organisateur_from_chasse($chasse_id) : null;
+    $email_organisateur = $organisateur_id ? get_field('email_organisateur', $organisateur_id) : '';
 
     if (!is_email($email_organisateur)) {
         $email_organisateur = get_option('admin_email');

--- a/templates/page-traitement-reponse.php
+++ b/templates/page-traitement-reponse.php
@@ -26,10 +26,17 @@ $enigme_id = (int) $tentative->enigme_id;
 
 // 🔐 Sécurité : vérifier que l'utilisateur connecté est bien organisateur associé
 $current_user_id = get_current_user_id();
-$chasse_raw = get_field('enigme_chasse_associee', $enigme_id, false);
-$chasse_id = is_array($chasse_raw) ? ($chasse_raw[0] ?? null) : $chasse_raw;
-$organisateur_id = get_organisateur_from_chasse($chasse_id);
-$organisateur_user_ids = get_field('utilisateurs_associes', $organisateur_id);
+$chasse_raw       = get_field('enigme_chasse_associee', $enigme_id, false);
+if (is_array($chasse_raw)) {
+    $first      = reset($chasse_raw);
+    $chasse_id  = is_object($first) ? (int) $first->ID : (int) $first;
+} elseif (is_object($chasse_raw)) {
+    $chasse_id  = (int) $chasse_raw->ID;
+} else {
+    $chasse_id  = (int) $chasse_raw;
+}
+$organisateur_id    = $chasse_id ? get_organisateur_from_chasse($chasse_id) : null;
+$organisateur_user_ids = $organisateur_id ? get_field('utilisateurs_associes', $organisateur_id) : [];
 
 if (
     !current_user_can('manage_options') &&
@@ -74,7 +81,15 @@ if ($exists) {
 $total_user = $wpdb->get_var($wpdb->prepare("SELECT COUNT(*) FROM $table WHERE user_id = %d AND enigme_id = %d", $user_id, $enigme_id));
 $total_enigme = $wpdb->get_var($wpdb->prepare("SELECT COUNT(*) FROM $table WHERE enigme_id = %d", $enigme_id));
 
-$chasse_id = get_field('enigme_chasse_associee', $enigme_id, false);
+$chasse_raw = get_field('enigme_chasse_associee', $enigme_id, false);
+if (is_array($chasse_raw)) {
+    $first     = reset($chasse_raw);
+    $chasse_id = is_object($first) ? (int) $first->ID : (int) $first;
+} elseif (is_object($chasse_raw)) {
+    $chasse_id = (int) $chasse_raw->ID;
+} else {
+    $chasse_id = (int) $chasse_raw;
+}
 $total_chasse = 0;
 
 if ($chasse_id) {


### PR DESCRIPTION
## Summary
- sanitize the ACF field `enigme_chasse_associee` before using its value
- avoid calling ACF with null IDs in `envoyer_mail_notification_joueur` and `envoyer_mail_accuse_reception_joueur`

## Testing
- `php -l templates/page-traitement-reponse.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e8681813c83328ba15232ccd878ad