### PR TITLE
Fix null site icon URL

### DIFF
--- a/templates/page-traitement-reponse.php
+++ b/templates/page-traitement-reponse.php
@@ -121,7 +121,8 @@ envoyer_mail_notification_joueur($user_id, $enigme_id, $resultat);
 ?>
 
 <div style="max-width:600px;margin:3em auto;text-align:center;font-family:sans-serif;">
-  <img src="<?= esc_url(get_site_icon_url(96)); ?>" alt="Logo" style="margin-bottom:1em; width:48px; height:48px;">
+  <?php $site_icon_url = get_site_icon_url(96); ?>
+  <img src="<?= esc_url($site_icon_url ?: ''); ?>" alt="Logo" style="margin-bottom:1em; width:48px; height:48px;">
   <p style="font-size:1.3em;">
     <?= $resultat === 'bon' ? '✅' : '❌'; ?> La réponse a bien été <strong><?= $resultat === 'bon' ? 'validée' : 'refusée'; ?></strong>.
   </p>


### PR DESCRIPTION
## Summary
- prevent deprecation warning by ensuring `get_site_icon_url()` doesn't pass null to `esc_url`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684e88154f248332ab5cd15d605eb264