### PR TITLE
Remove duplicate close window function

### DIFF
--- a/templates/page-traitement-reponse.php
+++ b/templates/page-traitement-reponse.php
@@ -115,19 +115,9 @@ if ($statut_actuel) {
       <a href="#" onclick="fermerFenetreOuRediriger(); return false;" style="margin-right:1em;">❎ Fermer cette fenêtre</a>
       <a href="<?= esc_url($permalink); ?>" style="background:#0073aa;padding:10px 20px;border-radius:5px;color:white;text-decoration:none;">🔍 Voir cette énigme</a>
     </div>
-  </div>
-  <script>
-    function fermerFenetreOuRediriger() {
-      window.close();
-      setTimeout(function() {
-        if (!window.closed) {
-          window.location.href = '/';
-        }
-      }, 500);
-    }
-  </script>
+    </div>
 <?php
-  $traitement_bloque = true;
+      $traitement_bloque = true;
 }
 
 $total_user = 0;


### PR DESCRIPTION
## Summary
- remove the first definition of `fermerFenetreOuRediriger()`
- keep only the closing-script at the page bottom

## Testing
- `npm test` *(fails: could not find package.json)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ef6cbce948332b8da4b86870e3c3e