### PR TITLE
Limit chasse creation for organiser_creation

### DIFF
--- a/inc/edition/edition-chasse.php
+++ b/inc/edition/edition-chasse.php
@@ -101,7 +101,10 @@ function creer_chasse_et_rediriger_si_appel()
     exit;
   }
 
-  $user_id = get_current_user_id();
+  $user       = wp_get_current_user();
+  $user_id    = (int) $user->ID;
+  $roles      = (array) $user->roles;
+
   error_log("👤 Utilisateur connecté : {$user_id}");
 
   // 📎 Récupération de l'organisateur lié
@@ -111,6 +114,17 @@ function creer_chasse_et_rediriger_si_appel()
     wp_die('Aucun organisateur associé.');
   }
   error_log("✅ Organisateur trouvé : {$organisateur_id}");
+
+  // 🔒 Vérification des droits de création
+  if (!current_user_can('administrator') && !current_user_can('organisateur')) {
+    if (in_array('organisateur_creation', $roles, true)) {
+      if (organisateur_a_des_chasses($organisateur_id)) {
+        wp_die('Limite atteinte');
+      }
+    } else {
+      wp_die('Accès refusé');
+    }
+  }
 
   // 📝 Création du post "chasse"
   $post_id = wp_insert_post([


### PR DESCRIPTION
## Summary
- restrict `utilisateur_peut_ajouter_chasse` with role checks
- secure `/creer-chasse/` endpoint to enforce those permissions

## Testing
- `php -l inc/access-functions.php` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_6857face08b08332a1818176f7f47921