### PR TITLE
Remove deprecated enigme_statut_utilisateur field

### DIFF
--- a/inc/access-functions.php
+++ b/inc/access-functions.php
@@ -669,11 +669,10 @@ function utilisateur_peut_voir_solution_enigme(int $enigme_id, int $user_id): bo
         return true;
     }
 
-    // 🧩 Joueur ayant résolu l’énigme — à adapter si tu as un suivi précis
-    // Ici, on suppose un champ utilisateur ACF du type enigme_statut_utilisateur[ID_ENIGME] = 'resolue'
-    $statuts = get_field('enigme_statut_utilisateur', 'user_' . $user_id);
-    if (is_array($statuts) && isset($statuts[$enigme_id])) {
-        return in_array($statuts[$enigme_id], ['resolue', 'terminee'], true);
+    // 🧩 Joueur ayant résolu l’énigme (statut stocké en base)
+    $statut = get_statut_utilisateur_enigme($user_id, $enigme_id);
+    if ($statut) {
+        return in_array($statut, ['resolue', 'terminee'], true);
     }
 
     return false;

--- a/notices/global.md
+++ b/notices/global.md
@@ -885,10 +885,12 @@ page enigme
 
 🏷️ Badges, statuts, affichages conditionnels
 
-L’affichage dynamique des boutons, statuts ou badges (sur les énigmes notamment) dépend de deux champs ACF distincts :
+L’affichage dynamique des boutons, statuts ou badges (sur les énigmes notamment)
+dépend du champ ACF `enigme_cache_etat_systeme` et du suivi individuel stocké
+dans la table `wp_enigme_statuts_utilisateur` :
 
-- enigme_cache_etat_systeme → etat logique global, calcule automatiquement
-- enigme_statut_utilisateur → etat individuel de progression du joueur
+- `enigme_cache_etat_systeme` → état logique global, calculé automatiquement
+- `wp_enigme_statuts_utilisateur` → statut individuel du joueur
 
 Ces deux champs combines determinent :
 - le bouton visible (CTA)
@@ -908,8 +910,8 @@ Definit si l enigme est techniquement disponible ou non.
 | invalide           | Donnees manquantes ou mal configurees            |
 | cache_invalide     | Erreur technique, logique ACF cassee             |
 
-👤 enigme_statut_utilisateur – etat individuel du joueur
-Definit le niveau de progression du joueur sur une enigme donnee (stocke individuellement).
+👤 Statut individuel du joueur (table `wp_enigme_statuts_utilisateur`)
+Definit le niveau de progression du joueur sur une enigme donnee.
 
 | Valeur        | Description                                         |
 |---------------|-----------------------------------------------------|


### PR DESCRIPTION
## Summary
- remove legacy `enigme_statut_utilisateur` logic
- document new table `wp_enigme_statuts_utilisateur`

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68581845cea08332a37ef683033738c2