### PR TITLE
Update organizer header icons

### DIFF
--- a/assets/css/organisateurs.css
+++ b/assets/css/organisateurs.css
@@ -113,6 +113,29 @@
     margin-top:1rem;
 }
 
+/* ========== 📌 ICÔNES D'ACTIONS ========== */
+.header-organisateur__actions {
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.header-organisateur__actions a,
+.header-organisateur__actions button {
+  color: var(--color-text-primary);
+  background: none;
+  border: none;
+  font-size: 1.2rem;
+  cursor: pointer;
+  transition: color 0.2s ease;
+}
+
+.header-organisateur__actions a:hover,
+.header-organisateur__actions button:hover {
+  color: var(--color-accent);
+}
+
 /* ========== 🖼 LOGO CLIQUABLE ========== */
 
 
@@ -121,84 +144,6 @@
 }
 
 
-/* ========== 🧭 MENU DE NAVIGATION ========== */
-
-.header-organisateur__menu-bar {
-  background-color: rgba(255, 255, 255, 0.03);
-  padding: 0.4rem 1.5rem;
-  margin-top: 0;
-  border-top: 1px solid rgba(255, 255, 255, 0.06);
-
-}
-.header-organisateur__bas {
-  display: flex;
-    justify-content: center;
-    align-items: center;
-    gap: 2rem;
-    width: 100%;
-}
-.header-organisateur__menu {
-    margin-top: 0; /* ou laisse vide si inutilisé ailleurs */
-}
-.header-organisateur__menu ul {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 1.5rem;
-    list-style: none;
-    padding: 0;
-    margin: 0;
-}
-
-.header-organisateur__menu a {
-    color: var(--color-text-primary);
-    text-decoration: none;
-    font-weight: 500;
-}
-
-.header-organisateur__menu .active a {
-    border-bottom: 2px solid var(--color-primary);
-}
-
-.header-organisateur__quitter {
-    margin-left: auto;
-}
-/* 🎯 MENU SOUS LE TITRE */
-.header-organisateur__menu--sous-titre {
-    margin-top: 0;
-}
-
-.header-organisateur__menu--sous-titre ul {
-    justify-content: center;
-    gap: 2.5rem;
-}
-
-/* 🔁 Animation de soulignement fluide au hover */
-.header-organisateur__menu--sous-titre a {
-    font-size: 1rem;
-    font-weight: 500;
-    position: relative;
-    padding-bottom: 0.2rem;
-    transition: color 0.2s ease;
-}
-
-.header-organisateur__menu--sous-titre a::after {
-  content: '';
-  position: absolute;
-  bottom: 0;
-  left: 0;
-  width: 0%;
-  height: 2px;
-  background-color: var(--color-primary);
-  transition: width 0.3s ease;
-}
-
-.header-organisateur__menu--sous-titre a:hover::after {
-  width: 100%;
-}
-
-.header-organisateur__menu--sous-titre .active a::after {
-  width: 100%;
-}
 
 /* ========== 🧭 MODAL BIENVENUE ========== */
 
@@ -368,9 +313,6 @@
         max-width: none;
         margin: 0 auto;
     }
-    .header-organisateur__menu ul {
-        justify-content: center;
-    }
 
   .colonne-texte {
     align-items: center;
@@ -496,18 +438,6 @@
     background-color: rgba(255, 255, 255, 0.04);
   }
 
-  /* 🔹 Menu navigation */
-  .header-organisateur__menu {
-    margin-top: 0;
-  }
-
-  .header-organisateur__menu ul {
-    gap: 1rem;
-  }
-
-  .header-organisateur__menu a {
-    font-size: 0.9rem;
-  }
 
   /* 🔹 Panneau latéral */
   .ligne-lien-formulaire label {

--- a/assets/js/header-organisateur-ui.js
+++ b/assets/js/header-organisateur-ui.js
@@ -2,39 +2,21 @@
 // 📁 header-organisateur-ui.js
 // Gère les interactions visuelles du header organisateur :
 // - Sliders édition 
-// - Navigation à onglets (chasses / présentation / contact)
+// - Affichage/masquage de la description via l’icône info
 // - Panneau latéral ACF (présentation)
 // ========================================
 
 document.addEventListener('DOMContentLoaded', () => {
 
-  // ✅ Nav menu : clic sur #presentation => affichage section
-  document.querySelectorAll('.header-organisateur__menu a[href^="#"]').forEach((lien) => {
-    lien.addEventListener('click', () => {
-      const target = lien.getAttribute('href');
-      const presentation = document.getElementById('presentation');
-
-      // Section à afficher / cacher
-      if (target === '#presentation') {
-        presentation?.classList.remove('masque');
-      } else {
-        presentation?.classList.add('masque');
-      }
-
-      // Liens actifs
-      document.querySelectorAll('.header-organisateur__menu li').forEach((li) => li.classList.remove('active'));
-      lien.closest('li')?.classList.add('active');
-    });
+  // ✅ Icône info : affichage/masquage de la description
+  document.querySelector('.bouton-toggle-description')?.addEventListener('click', () => {
+    const presentation = document.getElementById('presentation');
+    presentation?.classList.toggle('masque');
   });
 
   // ✅ Hash auto (si présentation dans l’URL)
   if (window.location.hash === '#presentation') {
     document.getElementById('presentation')?.classList.remove('masque');
-    const liPresentation = document.querySelector('.onglet-presentation');
-    if (liPresentation) {
-      document.querySelectorAll('.header-organisateur__menu li').forEach(li => li.classList.remove('active'));
-      liPresentation.classList.add('active');
-    }
   }
 
   // ✅ Panneau latéral ACF – ouverture (bouton déclencheur)

--- a/template-parts/organisateur/organisateur-header.php
+++ b/template-parts/organisateur/organisateur-header.php
@@ -75,23 +75,15 @@ $url_contact = esc_url($base_url . 'contact?email_organisateur=' . urlencode($em
       </div>
 
       <div class="champ-feedback"></div>
-    </div>
 
-    <!-- Bande menu en dehors du flex principal -->
-    <div class="header-organisateur__menu-bar">
-      <nav class="header-organisateur__menu header-organisateur__menu--sous-titre">
-        <ul>
-          <li class="onglet-chasses <?= !$est_contact ? 'active' : ''; ?>">
-            <a href="<?= esc_url($est_contact ? $base_url . '#chasses' : '#chasses'); ?>">Chasses</a>
-          </li>
-          <li class="onglet-presentation <?= !$est_contact ? '' : ''; ?>">
-            <a href="<?= esc_url($est_contact ? $base_url . '#presentation' : '#presentation'); ?>">Présentation</a>
-          </li>
-          <li class="onglet-contact <?= $est_contact ? 'active' : ''; ?>">
-            <a href="<?= esc_url($url_contact); ?>" class="onglet-nav">Contact</a>
-          </li>
-        </ul>
-      </nav>
+      <div class="header-organisateur__actions">
+        <button type="button" class="bouton-toggle-description" aria-label="Voir la description">
+          <i class="fa-solid fa-circle-info"></i>
+        </button>
+        <a href="<?= esc_url($url_contact); ?>" class="lien-contact" aria-label="Contact">
+          <i class="fa-solid fa-envelope"></i>
+        </a>
+      </div>
     </div>
 
     <!-- Icône réglage (toggle panneau + stylos) -->


### PR DESCRIPTION
## Summary
- swap organizer submenu links for info and contact icons
- toggle presentation panel with new info icon
- style new organizer header icons
- drop old organizer submenu styles

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685847f6c5a48332a9dfccd48c20b0e2