### PR TITLE
Fix double AJAX on date change

### DIFF
--- a/assets/js/chasse-edit.js
+++ b/assets/js/chasse-edit.js
@@ -7,8 +7,6 @@ let inputDateFin;
 let erreurDebut;
 let erreurFin;
 let checkboxIllimitee;
-let ancienneValeurDebut = '';
-let ancienneValeurFin = '';
 
 
 document.addEventListener('DOMContentLoaded', () => {
@@ -96,9 +94,7 @@ document.addEventListener('DOMContentLoaded', () => {
   // ==============================
   // 📅 Gestion Date de fin + Durée illimitée
   // ==============================
-  let ancienneValeurFin = '';
   if (inputDateFin) {
-    let ancienneValeurFin = inputDateFin.value;
 
     if (checkboxIllimitee) {
       inputDateFin.disabled = checkboxIllimitee.checked;
@@ -171,52 +167,6 @@ document.addEventListener('DOMContentLoaded', () => {
       });
     }
 
-    inputDateFin.addEventListener('change', function () {
-      const sauvegardeAvantChangement = this.value;
-
-      const valid = validerDatesAvantEnvoi('fin');
-      if (!valid) {
-        this.value = ancienneValeurFin;
-        return;
-      }
-
-      const nouvelleDateFin = this.value;
-      const regexDate = /^\d{4}-\d{2}-\d{2}$/;
-
-      if (!regexDate.test(nouvelleDateFin)) {
-        console.error('❌ Format de date fin invalide:', nouvelleDateFin);
-        this.value = ancienneValeurFin;
-        return;
-      }
-
-      const postId = this.closest('.champ-chasse')?.dataset.postId;
-      modifierChampSimple('caracteristiques.chasse_infos_date_fin', nouvelleDateFin, postId);
-      rafraichirStatutChasse(postId);
-
-      mettreAJourAffichageDateFin();
-
-      ancienneValeurFin = nouvelleDateFin;
-    });
-  }
-  if (inputDateDebut) {
-    ancienneValeurDebut = inputDateDebut.value;
-
-    inputDateDebut.addEventListener('change', function () {
-      const nouvelleDateDebut = this.value;
-      const regexDate = /^\d{4}-\d{2}-\d{2}$/;
-
-      if (!regexDate.test(nouvelleDateDebut)) {
-        console.error('❌ Format de date début invalide:', nouvelleDateDebut);
-        this.value = ancienneValeurDebut;
-        return;
-      }
-
-      const postId = this.closest('.champ-chasse')?.dataset.postId;
-      modifierChampSimple('caracteristiques.chasse_infos_date_debut', nouvelleDateDebut, postId);
-      rafraichirStatutChasse(postId);
-
-      ancienneValeurDebut = nouvelleDateDebut;
-    });
   }
 
 


### PR DESCRIPTION
## Summary
- centralise date saving through `modifierChampSimple`
- remove redundant date listeners from `chasse-edit.js`

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6858481993d48332bbdf29dee014a293