### PR TITLE
Add validation for start date

### DIFF
--- a/assets/js/chasse-edit.js
+++ b/assets/js/chasse-edit.js
@@ -202,6 +202,14 @@ document.addEventListener('DOMContentLoaded', () => {
     ancienneValeurDebut = inputDateDebut.value;
 
     inputDateDebut.addEventListener('change', function () {
+      const sauvegardeAvantChangement = this.value;
+
+      const valid = validerDatesAvantEnvoi('debut');
+      if (!valid) {
+        this.value = ancienneValeurDebut;
+        return;
+      }
+
       const nouvelleDateDebut = this.value;
       const regexDate = /^\d{4}-\d{2}-\d{2}$/;
 


### PR DESCRIPTION
## Summary
- validate start date before saving in `chasse-edit.js`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685848183418833281da6c503b9c743d