### PR TITLE
Fix header icons display

### DIFF
--- a/assets/css/organisateurs.css
+++ b/assets/css/organisateurs.css
@@ -126,9 +126,13 @@
   color: var(--color-text-primary);
   background: none;
   border: none;
-  font-size: 1.2rem;
+  font-size: 1.4rem;
   cursor: pointer;
   transition: color 0.2s ease;
+}
+
+.header-organisateur__actions .bouton-edition-toggle {
+  font-size: 1.2rem;
 }
 
 .header-organisateur__actions a:hover,

--- a/template-parts/organisateur/organisateur-header.php
+++ b/template-parts/organisateur/organisateur-header.php
@@ -83,14 +83,10 @@ $url_contact = esc_url($base_url . 'contact?email_organisateur=' . urlencode($em
         <a href="<?= esc_url($url_contact); ?>" class="lien-contact" aria-label="Contact">
           <i class="fa-solid fa-envelope"></i>
         </a>
+        <button id="toggle-mode-edition" class="bouton-edition-toggle" aria-label="Paramètres organisateur">
+          <i class="fa-solid fa-sliders"></i>
+        </button>
       </div>
-    </div>
-
-    <!-- Icône réglage (toggle panneau + stylos) -->
-    <div class="header-actions-droite">
-      <button id="toggle-mode-edition" class="bouton-edition-toggle" aria-label="Paramètres organisateur">
-        <i class="fa-solid fa-sliders"></i>
-      </button>
     </div>
 
   </header>


### PR DESCRIPTION
## Summary
- keep edition icon inside the actions block
- enlarge description and contact icons for organiser header

## Testing
- `npm test` *(fails: package.json missing)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68584f999fc88332910e1be071aaf90d