### PR TITLE
Fix organiser info panel on enigme pages

### DIFF
--- a/inc/organisateur-functions.php
+++ b/inc/organisateur-functions.php
@@ -33,7 +33,7 @@ defined( 'ABSPATH' ) || exit;
  * @return void
  */
 function enqueue_script_header_organisateur_ui() {
-    if (is_singular(['organisateur', 'chasse'])) {
+    if (is_singular(['organisateur', 'chasse', 'enigme'])) {
         $path = '/assets/js/header-organisateur-ui.js';
         wp_enqueue_script(
             'header-organisateur-ui',


### PR DESCRIPTION
## Summary
- make `header-organisateur-ui.js` load on `enigme` posts so the description panel works

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6858544263f883329f47663f8a8dc851