### PR TITLE
Remove status banner from quest page

### DIFF
--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -385,17 +385,6 @@ button,
 .badge-statut.statut-revision {
   background-color: var(--color-editor-error);
 }
-.statut-banner {
-  width: 100%;
-  padding: 8px 12px;
-  font-size: 0.85rem;
-  font-weight: bold;
-  text-align: center;
-  color: #fff;
-  background-color: var(--color-editor-error);
-  border-radius: 4px 4px 0 0;
-  margin-bottom: 0.5rem;
-}
 
 
 

--- a/template-parts/chasse/chasse-affichage-complet.php
+++ b/template-parts/chasse/chasse-affichage-complet.php
@@ -74,22 +74,6 @@ if (current_user_can('administrator')) {
 
 
 <section class="chasse-section-intro">
-  <?php
-  $validation = get_field('champs_caches')['chasse_cache_statut_validation'] ?? 'creation';
-
-  $messages = [
-    'creation'   => "Visibilité confidentielle. Cette chasse est en cours de création.",
-    'en_attente' => "Visibilité confidentielle. Cette chasse a été soumise à validation.",
-    'correction' => "Visibilité confidentielle. Cette chasse nécessite des ajustements.",
-    'banni'      => "Non publiée. Cette chasse a été refusée par l’équipe."
-  ];
-
-  if ($validation !== 'valide' && isset($messages[$validation])) :
-  ?>
-    <div class="statut-banner">
-      <?= esc_html($messages[$validation]); ?>
-    </div>
-  <?php endif; ?>
 
   <div class="chasse-fiche-container flex-row">
     <?php


### PR DESCRIPTION
## Summary
- remove validation banner logic in quest template
- clean up unused CSS rule for the banner

## Testing
- `php -l template-parts/chasse/chasse-affichage-complet.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685858ab821c8332ae3c2cfa8773375c