### PR TITLE
Redesign edition panels as modals with tabs

### DIFF
--- a/assets/css/edition.css
+++ b/assets/css/edition.css
@@ -470,6 +470,19 @@ body.edition-active-enigme .edition-panel-enigme {
   overflow-y: auto;
 }
 
+body.edition-active .panneau-organisateur.edition-panel-modal,
+body.edition-active-chasse .edition-panel-chasse.edition-panel-modal,
+body.edition-active-enigme .edition-panel-enigme.edition-panel-modal {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 95%;
+  max-height: 90vh;
+  border-radius: 8px;
+  z-index: 10000;
+}
+
 .edition-panel-header {
   display: flex;
   justify-content: space-between;
@@ -841,4 +854,36 @@ body.panneau-ouvert::before {
   pointer-events: none;
   opacity: 0.5;
   filter: grayscale(100%);
+}
+
+/* ==================================================
+   🗂️ ONGLET MODAL D'ÉDITION
+   ================================================== */
+
+.edition-tabs {
+  display: flex;
+  gap: 0.5rem;
+  border-bottom: 1px solid var(--color-editor-border);
+  margin-bottom: 1rem;
+}
+
+.edition-tab {
+  background: none;
+  border: none;
+  padding: 0.5rem 1rem;
+  cursor: pointer;
+  font-weight: 600;
+  color: var(--color-editor-text);
+}
+
+.edition-tab.active {
+  border-bottom: 3px solid var(--color-primary);
+}
+
+.edition-tab-content {
+  display: none;
+}
+
+.edition-tab-content.active {
+  display: block;
 }

--- a/assets/js/chasse-edit.js
+++ b/assets/js/chasse-edit.js
@@ -45,9 +45,11 @@ document.addEventListener('DOMContentLoaded', () => {
   // ==============================
   document.getElementById('toggle-mode-edition-chasse')?.addEventListener('click', () => {
     document.body.classList.toggle('edition-active-chasse');
+    document.body.classList.toggle('panneau-ouvert');
   });
   document.querySelector('.edition-panel-chasse .panneau-fermer')?.addEventListener('click', () => {
     document.body.classList.remove('edition-active-chasse');
+    document.body.classList.remove('panneau-ouvert');
     document.activeElement?.blur();
   });
 

--- a/assets/js/core/modal-tabs.js
+++ b/assets/js/core/modal-tabs.js
@@ -1,0 +1,28 @@
+// Gestion des onglets pour les panneaux d'édition modaux
+
+(function() {
+  document.addEventListener('DOMContentLoaded', () => {
+    document.querySelectorAll('.edition-tabs').forEach(tabs => {
+      const container = tabs.closest('.edition-panel-modal');
+      if (!container) return;
+      const buttons = tabs.querySelectorAll('.edition-tab');
+      buttons.forEach(btn => {
+        btn.addEventListener('click', () => {
+          const target = btn.dataset.target;
+          if (!target) return;
+          buttons.forEach(b => b.classList.remove('active'));
+          btn.classList.add('active');
+          container.querySelectorAll('.edition-tab-content').forEach(content => {
+            if (content.id === target) {
+              content.style.display = '';
+              content.classList.add('active');
+            } else {
+              content.style.display = 'none';
+              content.classList.remove('active');
+            }
+          });
+        });
+      });
+    });
+  });
+})();

--- a/assets/js/enigme-edit.js
+++ b/assets/js/enigme-edit.js
@@ -16,11 +16,13 @@ document.addEventListener('DOMContentLoaded', () => {
   // ==============================
   boutonToggle?.addEventListener('click', () => {
     document.body.classList.toggle('edition-active-enigme');
+    document.body.classList.toggle('panneau-ouvert');
   });
 
 
   panneauEdition?.querySelector('.panneau-fermer')?.addEventListener('click', () => {
     document.body.classList.remove('edition-active-enigme');
+    document.body.classList.remove('panneau-ouvert');
     document.activeElement?.blur();
   });
 

--- a/assets/js/organisateur-edit.js
+++ b/assets/js/organisateur-edit.js
@@ -36,11 +36,13 @@ document.addEventListener('DOMContentLoaded', () => {
   // ⚙️ Bouton toggle header
   document.getElementById('toggle-mode-edition')?.addEventListener('click', () => {
     document.body.classList.toggle('edition-active');
+    document.body.classList.toggle('panneau-ouvert');
   });
 
   // ✖ Fermeture du panneau organisateur
   document.querySelector('.panneau-organisateur .panneau-fermer')?.addEventListener('click', () => {
     document.body.classList.remove('edition-active');
+    document.body.classList.remove('panneau-ouvert');
     document.activeElement?.blur();
   });
 

--- a/inc/edition/edition-core.php
+++ b/inc/edition/edition-core.php
@@ -88,6 +88,7 @@ function enqueue_core_edit_scripts()
     'date-fields'      => 'date-fields.js',
     'champ-init'       => 'champ-init.js',
     'champ-date-hooks' => 'champ-date-hooks.js',
+    'modal-tabs'       => 'modal-tabs.js',
   ];
 
   $previous_handle = null;

--- a/template-parts/chasse/chasse-edition-main.php
+++ b/template-parts/chasse/chasse-edition-main.php
@@ -34,7 +34,7 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
 ?>
 
 <?php if ($peut_modifier) : ?>
-  <section class="edition-panel edition-panel-chasse" data-cpt="chasse" data-post-id="<?= esc_attr($chasse_id); ?>">
+  <section class="edition-panel edition-panel-chasse edition-panel-modal" data-cpt="chasse" data-post-id="<?= esc_attr($chasse_id); ?>">
     <div id="erreur-global" style="display:none; background:red; color:white; padding:5px; text-align:center; font-size:0.9em;"></div>
 
     <div class="edition-panel-header">
@@ -42,7 +42,14 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
       <button type="button" class="panneau-fermer" aria-label="Fermer les paramètres">✖</button>
     </div>
 
-    <div class="edition-panel-body">
+    <div class="edition-tabs">
+      <button class="edition-tab active" data-target="chasse-tab-param">Paramètres</button>
+      <button class="edition-tab" data-target="chasse-tab-stats">Statistiques</button>
+      <button class="edition-tab" data-target="chasse-tab-spec">Champs spécifiques</button>
+    </div>
+
+    <div id="chasse-tab-param" class="edition-tab-content active">
+      <div class="edition-panel-body">
 
       <!-- 🎯 ACCORDÉON 1 : Paramètres principaux -->
       <div class="edition-panel-section edition-panel-section-ligne accordeon-bloc" data-bloc="profil">
@@ -282,6 +289,15 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
         </div>
       </div>
 
+    </div> <!-- .edition-panel-body -->
+    </div> <!-- #chasse-tab-param -->
+
+    <div id="chasse-tab-stats" class="edition-tab-content" style="display:none;">
+      <p>Statistiques à venir.</p>
+    </div>
+
+    <div id="chasse-tab-spec" class="edition-tab-content" style="display:none;">
+      <p>Classement prochainement disponible.</p>
     </div>
 
     <div class="edition-panel-footer"></div>

--- a/template-parts/enigme/enigme-edition-main.php
+++ b/template-parts/enigme/enigme-edition-main.php
@@ -60,7 +60,7 @@ $has_variantes = ($nb_variantes > 0);
 ?>
 
 <?php if ($peut_modifier) : ?>
-  <section class="edition-panel edition-panel-enigme" data-cpt="enigme" data-post-id="<?= esc_attr($enigme_id); ?>">
+  <section class="edition-panel edition-panel-enigme edition-panel-modal" data-cpt="enigme" data-post-id="<?= esc_attr($enigme_id); ?>">
     <div id="erreur-global"
       style="display:none; background:red; color:white; padding:5px; text-align:center; font-size:0.9em;"></div>
 
@@ -79,7 +79,14 @@ $has_variantes = ($nb_variantes > 0);
       <button type="button" class="panneau-fermer" aria-label="Fermer les paramètres">✖</button>
     </div>
 
-    <div class="edition-panel-body edition-panel-section">
+    <div class="edition-tabs">
+      <button class="edition-tab active" data-target="enigme-tab-param">Paramètres</button>
+      <button class="edition-tab" data-target="enigme-tab-stats">Statistiques</button>
+      <button class="edition-tab" data-target="enigme-tab-spec">Champs spécifiques</button>
+    </div>
+
+    <div id="enigme-tab-param" class="edition-tab-content active">
+      <div class="edition-panel-body edition-panel-section">
       <div class="resume-blocs-grid deux-col-wrapper">
         <div class="resume-bloc resume-obligatoire deux-col-bloc">
 
@@ -367,6 +374,16 @@ $has_variantes = ($nb_variantes > 0);
 
             </fieldset>
 
+        </div>
+      </div>
+    </div>
+    </div> <!-- .edition-panel-body -->
+    </div> <!-- #enigme-tab-param -->
+
+<div id="enigme-tab-spec" class="edition-tab-content" style="display:none;">
+
+      <p>Soumission : fonctionnalité à venir.</p>
+      <p>Indices : fonctionnalité à venir.</p>
 
             <fieldset class="groupe-champ champ-groupe-solution">
               <legend>Publication de la solution</legend>
@@ -445,6 +462,7 @@ $has_variantes = ($nb_variantes > 0);
         </div>
       </div>
     </div>
+    </div> <!-- #enigme-tab-spec -->
     <div class="edition-panel-footer"></div>
   </section>
 <?php endif; ?>

--- a/template-parts/organisateur/organisateur-edition-main.php
+++ b/template-parts/organisateur/organisateur-edition-main.php
@@ -38,7 +38,7 @@ $classe_vide_coordonnees = ($iban_vide || $bic_vide) ? 'champ-vide' : '';
 ?>
 
 <?php if ($edition_active && $peut_modifier) : ?>
-  <section class="panneau-organisateur edition-panel edition-panel-organisateur edition-active" aria-hidden="false">
+  <section class="panneau-organisateur edition-panel edition-panel-organisateur edition-panel-modal edition-active" aria-hidden="false">
 
     <div class="edition-panel-header">
       <h2><i class="fa-solid fa-sliders"></i> Paramètres organisateur</h2>
@@ -47,8 +47,14 @@ $classe_vide_coordonnees = ($iban_vide || $bic_vide) ? 'champ-vide' : '';
       </button>
     </div>
 
+    <div class="edition-tabs">
+      <button class="edition-tab active" data-target="organisateur-tab-param">Paramètres</button>
+      <button class="edition-tab" data-target="organisateur-tab-stats">Statistiques</button>
+      <button class="edition-tab" data-target="organisateur-tab-spec">Champs spécifiques</button>
+    </div>
 
-    <div class="edition-panel-body">
+    <div id="organisateur-tab-param" class="edition-tab-content active">
+      <div class="edition-panel-body">
       <div class="edition-panel-section edition-panel-section-ligne accordeon-bloc" data-bloc="profil">
         <button class="accordeon-toggle" aria-expanded="true">
           <span class="label">
@@ -221,7 +227,17 @@ $classe_vide_coordonnees = ($iban_vide || $bic_vide) ? 'champ-vide' : '';
           <p class="info-a-suivre">Rendez-vous prochainement pour plus de fonctionnalités !</p>
         </div>
       </div>
+    </div> <!-- .edition-panel-body -->
+    </div> <!-- #organisateur-tab-param -->
+
+    <div id="organisateur-tab-stats" class="edition-tab-content" style="display:none;">
+      <p>Statistiques en cours de développement.</p>
     </div>
+
+    <div id="organisateur-tab-spec" class="edition-tab-content" style="display:none;">
+      <p>Actualités bientôt disponibles.</p>
+    </div>
+
     <div class="edition-panel-footer"></div>
   </section>
 <?php endif; ?>


### PR DESCRIPTION
## Summary
- load new `modal-tabs.js` with core edit scripts
- style edition panels as modal dialogs and add tab support
- toggle the overlay when opening edition panels
- structure organiser, hunt and enigma panels with new tabs
- move the solution block to the Enigme 'Champs spécifiques' tab

## Testing
- `php` was not available so no linting could run

------
https://chatgpt.com/codex/tasks/task_e_68586a9515948332a721518b8d75de14