### PR TITLE
Implémente nouveaux onglets d’édition

### DIFF
--- a/inc/enigme-functions.php
+++ b/inc/enigme-functions.php
@@ -1151,7 +1151,7 @@
      * @param string $uid
      * @return string 'attente' | 'validee' | 'refusee' | 'invalide' | 'inexistante'
      */
-    function get_etat_tentative(string $uid): string
+function get_etat_tentative(string $uid): string
     {
         global $wpdb;
         $table = $wpdb->prefix . 'enigme_tentatives';
@@ -1163,4 +1163,39 @@
         if ($resultat === 'faux') return 'refusee';
 
         return 'invalide';
-    }
+}
+
+/**
+ * Récupère les tentatives enregistrées pour une énigme.
+ *
+ * @param int $enigme_id ID de l'énigme.
+ * @param int $limit     Nombre de résultats à retourner.
+ * @param int $offset    Décalage pour la pagination.
+ * @return array         Liste des tentatives.
+ */
+function recuperer_tentatives_enigme(int $enigme_id, int $limit = 25, int $offset = 0): array
+{
+    global $wpdb;
+    $table = $wpdb->prefix . 'enigme_tentatives';
+    $query = $wpdb->prepare(
+        "SELECT * FROM $table WHERE enigme_id = %d ORDER BY tentative_uid DESC LIMIT %d OFFSET %d",
+        $enigme_id,
+        $limit,
+        $offset
+    );
+    $res = $wpdb->get_results($query);
+    return $res ?: [];
+}
+
+/**
+ * Compte le nombre total de tentatives pour une énigme.
+ *
+ * @param int $enigme_id ID de l'énigme.
+ * @return int Nombre de tentatives.
+ */
+function compter_tentatives_enigme(int $enigme_id): int
+{
+    global $wpdb;
+    $table = $wpdb->prefix . 'enigme_tentatives';
+    return (int) $wpdb->get_var($wpdb->prepare("SELECT COUNT(*) FROM $table WHERE enigme_id = %d", $enigme_id));
+}

--- a/template-parts/chasse/chasse-edition-main.php
+++ b/template-parts/chasse/chasse-edition-main.php
@@ -45,7 +45,8 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
     <div class="edition-tabs">
       <button class="edition-tab active" data-target="chasse-tab-param">Paramètres</button>
       <button class="edition-tab" data-target="chasse-tab-stats">Statistiques</button>
-      <button class="edition-tab" data-target="chasse-tab-spec">Champs spécifiques</button>
+      <button class="edition-tab" data-target="chasse-tab-classement">Classement</button>
+      <button class="edition-tab" data-target="chasse-tab-indices">Indices</button>
     </div>
 
     <div id="chasse-tab-param" class="edition-tab-content active">
@@ -296,8 +297,12 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
       <p>Statistiques à venir.</p>
     </div>
 
-    <div id="chasse-tab-spec" class="edition-tab-content" style="display:none;">
+    <div id="chasse-tab-classement" class="edition-tab-content" style="display:none;">
       <p>Classement prochainement disponible.</p>
+    </div>
+
+    <div id="chasse-tab-indices" class="edition-tab-content" style="display:none;">
+      <p>Gestion des indices à venir.</p>
     </div>
 
     <div class="edition-panel-footer"></div>

--- a/template-parts/enigme/enigme-edition-main.php
+++ b/template-parts/enigme/enigme-edition-main.php
@@ -82,7 +82,9 @@ $has_variantes = ($nb_variantes > 0);
     <div class="edition-tabs">
       <button class="edition-tab active" data-target="enigme-tab-param">Paramètres</button>
       <button class="edition-tab" data-target="enigme-tab-stats">Statistiques</button>
-      <button class="edition-tab" data-target="enigme-tab-spec">Champs spécifiques</button>
+      <button class="edition-tab" data-target="enigme-tab-soumission">Soumission</button>
+      <button class="edition-tab" data-target="enigme-tab-indices">Indices</button>
+      <button class="edition-tab" data-target="enigme-tab-solution">Solution</button>
     </div>
 
     <div id="enigme-tab-param" class="edition-tab-content active">
@@ -380,10 +382,50 @@ $has_variantes = ($nb_variantes > 0);
     </div> <!-- .edition-panel-body -->
     </div> <!-- #enigme-tab-param -->
 
-<div id="enigme-tab-spec" class="edition-tab-content" style="display:none;">
+<div id="enigme-tab-soumission" class="edition-tab-content" style="display:none;">
+<?php
+  $page_tentatives = max(1, intval($_GET['page_tentatives'] ?? 1));
+  $par_page = 25;
+  $offset = ($page_tentatives - 1) * $par_page;
+  $tentatives = recuperer_tentatives_enigme($enigme_id, $par_page, $offset);
+  $total_tentatives = compter_tentatives_enigme($enigme_id);
+  if (empty($tentatives)) : ?>
+  <p>Aucune tentative de soumission.</p>
+<?php else : ?>
+  <table class="table-tentatives">
+    <thead>
+      <tr>
+        <th>Utilisateur</th>
+        <th>Réponse</th>
+        <th>Résultat</th>
+      </tr>
+    </thead>
+    <tbody>
+      <?php foreach ($tentatives as $tent) : ?>
+        <tr>
+          <td><?= esc_html(get_userdata($tent->user_id)?->display_name ?? 'Inconnu'); ?></td>
+          <td><?= esc_html($tent->reponse_saisie); ?></td>
+          <td><?= esc_html($tent->resultat); ?></td>
+        </tr>
+      <?php endforeach; ?>
+    </tbody>
+  </table>
+  <div class="pager" style="margin-top:10px;">
+    <?php if ($page_tentatives > 1) : ?>
+      <a href="<?= esc_url(add_query_arg('page_tentatives', $page_tentatives - 1)); ?>">&laquo; Préc.</a>
+    <?php endif; ?>
+    <?php if ($offset + $par_page < $total_tentatives) : ?>
+      <a href="<?= esc_url(add_query_arg('page_tentatives', $page_tentatives + 1)); ?>" style="margin-left:10px;">Suiv. &raquo;</a>
+    <?php endif; ?>
+  </div>
+<?php endif; ?>
+</div>
 
-      <p>Soumission : fonctionnalité à venir.</p>
-      <p>Indices : fonctionnalité à venir.</p>
+<div id="enigme-tab-indices" class="edition-tab-content" style="display:none;">
+  <p>Indices : fonctionnalité à venir.</p>
+</div>
+
+<div id="enigme-tab-solution" class="edition-tab-content" style="display:none;">
 
             <fieldset class="groupe-champ champ-groupe-solution">
               <legend>Publication de la solution</legend>
@@ -462,7 +504,7 @@ $has_variantes = ($nb_variantes > 0);
         </div>
       </div>
     </div>
-    </div> <!-- #enigme-tab-spec -->
+    </div> <!-- #enigme-tab-solution -->
     <div class="edition-panel-footer"></div>
   </section>
 <?php endif; ?>

--- a/template-parts/organisateur/organisateur-edition-main.php
+++ b/template-parts/organisateur/organisateur-edition-main.php
@@ -50,7 +50,7 @@ $classe_vide_coordonnees = ($iban_vide || $bic_vide) ? 'champ-vide' : '';
     <div class="edition-tabs">
       <button class="edition-tab active" data-target="organisateur-tab-param">Paramètres</button>
       <button class="edition-tab" data-target="organisateur-tab-stats">Statistiques</button>
-      <button class="edition-tab" data-target="organisateur-tab-spec">Champs spécifiques</button>
+      <button class="edition-tab" data-target="organisateur-tab-revenus">Revenus</button>
     </div>
 
     <div id="organisateur-tab-param" class="edition-tab-content active">
@@ -234,8 +234,8 @@ $classe_vide_coordonnees = ($iban_vide || $bic_vide) ? 'champ-vide' : '';
       <p>Statistiques en cours de développement.</p>
     </div>
 
-    <div id="organisateur-tab-spec" class="edition-tab-content" style="display:none;">
-      <p>Actualités bientôt disponibles.</p>
+    <div id="organisateur-tab-revenus" class="edition-tab-content" style="display:none;">
+      <p>Gestion des revenus en cours de développement.</p>
     </div>
 
     <div class="edition-panel-footer"></div>


### PR DESCRIPTION
## Summary
- onglet Revenus pour les organisateurs
- onglets Classement et Indices pour les chasses
- onglets Soumission, Indices et Solution pour les énigmes
- fonction utilitaire pour lister les tentatives d’énigmes

## Testing
- `npm test` *(fails: package.json missing)*
- `composer test` *(fails: command not found)*
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858c6f3ab288332a2178f2a958f4940