### PR TITLE
Refine auto-open logic for edit panels

### DIFF
--- a/inc/edition/edition-core.php
+++ b/inc/edition/edition-core.php
@@ -415,7 +415,8 @@ function injection_classe_edition_active(array $classes): array
     $post->post_type === 'organisateur' &&
     get_post_status($post) === 'pending' &&
     (int) get_post_field('post_author', $post->ID) === $user_id &&
-    in_array('organisateur_creation', $roles, true)
+    in_array('organisateur_creation', $roles, true) &&
+    !get_field('organisateur_cache_complet', $post->ID)
   ) {
     $classes[] = 'edition-active';
   }
@@ -424,7 +425,8 @@ function injection_classe_edition_active(array $classes): array
   if (
     $post->post_type === 'chasse' &&
     get_post_status($post) === 'pending' &&
-    in_array('organisateur_creation', $roles, true)
+    in_array('organisateur_creation', $roles, true) &&
+    !get_field('chasse_cache_complet', $post->ID)
   ) {
     $organisateur_id = get_organisateur_from_chasse($post->ID);
     $associes = get_field('utilisateurs_associes', $organisateur_id, false);

--- a/single-enigme.php
+++ b/single-enigme.php
@@ -26,9 +26,11 @@ if (!enigme_est_visible_pour($user_id, $enigme_id)) {
 
 // 🔹 Mode édition auto
 $edition_active = utilisateur_peut_modifier_post($enigme_id);
+$enigme_complete = (bool) get_field('enigme_cache_complet', $enigme_id);
 if (
   $edition_active &&
   current_user_can('organisateur_creation') &&
+  !$enigme_complete &&
   !isset($_GET['edition'])
 ) {
   wp_redirect(add_query_arg('edition', 'open', get_permalink()));

--- a/template-parts/organisateur/organisateur-edition-main.php
+++ b/template-parts/organisateur/organisateur-edition-main.php
@@ -12,7 +12,8 @@ $roles = (array) $current_user->roles;
 $profil_expanded = array_intersect($roles, ['organisateur_creation', 'abonne']);
 $profil_expanded = !empty($profil_expanded);
 $infos_expanded = !$profil_expanded;
-$edition_active = in_array('organisateur_creation', $roles);
+$cache_complet  = get_field('organisateur_cache_complet', $organisateur_id);
+$edition_active = in_array('organisateur_creation', $roles) && !$cache_complet;
 
 // Post
 $titre        = get_post_field('post_title', $organisateur_id);
@@ -37,8 +38,8 @@ $bic_vide  = empty($coordonnees['bic']);
 $classe_vide_coordonnees = ($iban_vide || $bic_vide) ? 'champ-vide' : '';
 ?>
 
-<?php if ($edition_active && $peut_modifier) : ?>
-  <section class="panneau-organisateur edition-panel edition-panel-organisateur edition-panel-modal edition-active" aria-hidden="false">
+<?php if ($peut_modifier) : ?>
+  <section class="panneau-organisateur edition-panel edition-panel-organisateur edition-panel-modal<?php echo $edition_active ? ' edition-active' : ''; ?>" aria-hidden="<?php echo $edition_active ? 'false' : 'true'; ?>">
 
     <div class="edition-panel-header">
       <h2><i class="fa-solid fa-sliders"></i> Paramètres organisateur</h2>


### PR DESCRIPTION
## Summary
- stop forcing body edit classes when CPTs are complete
- hide organizer panel on load if organizer is complete
- stop auto-opening enigme panel when the puzzle is complete

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6858c92bea348332a5d7bf5127c496c3