### PR TITLE
Placeholder pour onglets vides d'édition

### DIFF
--- a/assets/css/edition.css
+++ b/assets/css/edition.css
@@ -880,8 +880,10 @@ body.panneau-ouvert::before {
   border-bottom: 3px solid var(--color-primary);
 }
 
+
 .edition-tab-content {
   display: none;
+  min-height: 180px;
 }
 
 .edition-tab-content.active {

--- a/template-parts/chasse/chasse-edition-main.php
+++ b/template-parts/chasse/chasse-edition-main.php
@@ -294,15 +294,15 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
     </div> <!-- #chasse-tab-param -->
 
     <div id="chasse-tab-stats" class="edition-tab-content" style="display:none;">
-      <p>Statistiques à venir.</p>
+      <p class="edition-placeholder">xx à venir</p>
     </div>
 
     <div id="chasse-tab-classement" class="edition-tab-content" style="display:none;">
-      <p>Classement prochainement disponible.</p>
+      <p class="edition-placeholder">xx à venir</p>
     </div>
 
     <div id="chasse-tab-indices" class="edition-tab-content" style="display:none;">
-      <p>Gestion des indices à venir.</p>
+      <p class="edition-placeholder">xx à venir</p>
     </div>
 
     <div class="edition-panel-footer"></div>

--- a/template-parts/enigme/enigme-edition-main.php
+++ b/template-parts/enigme/enigme-edition-main.php
@@ -422,7 +422,7 @@ $has_variantes = ($nb_variantes > 0);
 </div>
 
 <div id="enigme-tab-indices" class="edition-tab-content" style="display:none;">
-  <p>Indices : fonctionnalité à venir.</p>
+  <p class="edition-placeholder">xx à venir</p>
 </div>
 
 <div id="enigme-tab-solution" class="edition-tab-content" style="display:none;">

--- a/template-parts/organisateur/organisateur-edition-main.php
+++ b/template-parts/organisateur/organisateur-edition-main.php
@@ -230,13 +230,13 @@ $classe_vide_coordonnees = ($iban_vide || $bic_vide) ? 'champ-vide' : '';
     </div> <!-- .edition-panel-body -->
     </div> <!-- #organisateur-tab-param -->
 
-    <div id="organisateur-tab-stats" class="edition-tab-content" style="display:none;">
-      <p>Statistiques en cours de développement.</p>
-    </div>
+      <div id="organisateur-tab-stats" class="edition-tab-content" style="display:none;">
+        <p class="edition-placeholder">xx à venir</p>
+      </div>
 
-    <div id="organisateur-tab-revenus" class="edition-tab-content" style="display:none;">
-      <p>Gestion des revenus en cours de développement.</p>
-    </div>
+      <div id="organisateur-tab-revenus" class="edition-tab-content" style="display:none;">
+        <p class="edition-placeholder">xx à venir</p>
+      </div>
 
     <div class="edition-panel-footer"></div>
   </section>


### PR DESCRIPTION
## Summary
- limite la variation de hauteur des onglets d'édition
- affiche `xx à venir` dans les onglets Stats, Classement et Indices des CPT
- même placeholder ajouté aux onglets Stats et Revenus des organisateurs

## Testing
- `php -l template-parts/organisateur/organisateur-edition-main.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6858ca70f2f88332ad860854e50531e7