### PR TITLE
Fix solution timing layout

### DIFF
--- a/assets/css/edition.css
+++ b/assets/css/edition.css
@@ -659,6 +659,27 @@ li.ligne-email .champ-organisateur .champ-affichage {
   text-align: unset;
 }
 
+/* Champs délai et heure de solution en ligne */
+.champ-solution-timing {
+  display: flex;
+  flex-wrap: nowrap;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.champ-solution-timing .champ-delai-inline {
+  width: 60px;
+  text-align: center;
+}
+
+.champ-solution-timing .champ-select-heure {
+  width: auto;
+}
+
+.champ-solution-timing span {
+  white-space: nowrap;
+}
+
 .edition-panel-section .champ-badge-cout {
   margin: 0 1rem;
 }

--- a/template-parts/enigme/enigme-edition-main.php
+++ b/template-parts/enigme/enigme-edition-main.php
@@ -475,7 +475,7 @@ $has_variantes = ($nb_variantes > 0);
                 </div>
 
                 <!-- ✅ Ligne publication -->
-                <div class="champ-solution-timing" style="margin-top: 15px; display: flex; flex-wrap: wrap; align-items: center; gap: 0.5rem;">
+                <div class="champ-solution-timing" style="margin-top: 15px;">
                   <label for="solution-delai" style="margin-right: 8px;">Publication :</label>
 
                   <input type="number"
@@ -484,8 +484,7 @@ $has_variantes = ($nb_variantes > 0);
                     step="1"
                     value="<?= esc_attr($delai); ?>"
                     id="solution-delai"
-                    class="champ-input champ-delai-inline"
-                    style="width: 60px; text-align: center;">
+                    class="champ-input champ-delai-inline">
 
                   <span>jours après la fin de la chasse, à</span>
 
@@ -495,6 +494,7 @@ $has_variantes = ($nb_variantes > 0);
                       <option value="<?= $formatted; ?>" <?= $formatted === $heure ? 'selected' : ''; ?>><?= $formatted; ?></option>
                     <?php endforeach; ?>
                   </select>
+                  <span>heure.</span>
                 </div>
 
               </div>


### PR DESCRIPTION
## Summary
- keep solution scheduling controls on one line
- add missing text "heure." after hour selection
- style solution timing row via CSS

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858cb3673b883328ca54f7100e2cb02