### PR TITLE
Sync cache completion fields on page view

### DIFF
--- a/inc/edition/edition-core.php
+++ b/inc/edition/edition-core.php
@@ -413,17 +413,22 @@ function injection_classe_edition_active(array $classes): array
   // === ORGANISATEUR ===
   if (
     $post->post_type === 'organisateur' &&
-    get_post_status($post) === 'pending' &&
     (int) get_post_field('post_author', $post->ID) === $user_id &&
     in_array('organisateur_creation', $roles, true)
   ) {
-    $classes[] = 'edition-active';
+    verifier_ou_mettre_a_jour_cache_complet($post->ID);
+
+    if (
+      get_post_status($post) === 'pending' &&
+      !get_field('organisateur_cache_complet', $post->ID)
+    ) {
+      $classes[] = 'edition-active';
+    }
   }
 
   // === CHASSE ===
   if (
     $post->post_type === 'chasse' &&
-    get_post_status($post) === 'pending' &&
     in_array('organisateur_creation', $roles, true)
   ) {
     $organisateur_id = get_organisateur_from_chasse($post->ID);
@@ -431,7 +436,14 @@ function injection_classe_edition_active(array $classes): array
     $associes = is_array($associes) ? array_map('strval', $associes) : [];
 
     if (in_array((string) $user_id, $associes, true)) {
-      $classes[] = 'edition-active-chasse';
+      verifier_ou_mettre_a_jour_cache_complet($post->ID);
+
+      if (
+        get_post_status($post) === 'pending' &&
+        !get_field('chasse_cache_complet', $post->ID)
+      ) {
+        $classes[] = 'edition-active-chasse';
+      }
     }
   }
 

--- a/inc/statut-functions.php
+++ b/inc/statut-functions.php
@@ -619,6 +619,59 @@ function mettre_a_jour_cache_complet_automatiquement($post_id): void
 }
 add_action('acf/save_post', 'mettre_a_jour_cache_complet_automatiquement', 20);
 
+/**
+ * Vérifie la valeur du champ `_cache_complet` d'un post et la
+ * synchronise si elle ne correspond pas à la réalité.
+ *
+ * Cette vérification est légère et peut être appelée à chaque
+ * affichage d'un post (ex : pages single) pour s'assurer que les
+ * panneaux d'édition ne s'ouvrent pas inutilement.
+ *
+ * @param int $post_id ID du post à contrôler.
+ * @return void
+ */
+function verifier_ou_mettre_a_jour_cache_complet(int $post_id): void
+{
+    if (!is_numeric($post_id)) {
+        return;
+    }
+
+    static $deja = [];
+    if (in_array($post_id, $deja, true)) {
+        return;
+    }
+    $deja[] = $post_id;
+
+    $type = get_post_type($post_id);
+
+    switch ($type) {
+        case 'organisateur':
+            $cache = (bool) get_field('organisateur_cache_complet', $post_id);
+            $reel  = organisateur_est_complet($post_id);
+            if ($cache !== $reel) {
+                update_field('organisateur_cache_complet', $reel ? 1 : 0, $post_id);
+            }
+            break;
+
+        case 'chasse':
+            $cache = (bool) get_field('chasse_cache_complet', $post_id);
+            $reel  = chasse_est_complet($post_id);
+            if ($cache !== $reel) {
+                update_field('chasse_cache_complet', $reel ? 1 : 0, $post_id);
+            }
+            break;
+
+        case 'enigme':
+            $cache = (bool) get_field('enigme_cache_complet', $post_id);
+            $reel  = enigme_est_complet($post_id);
+            if ($cache !== $reel) {
+                update_field('enigme_cache_complet', $reel ? 1 : 0, $post_id);
+            }
+            break;
+    }
+}
+
+
 
 
 

--- a/single-chasse.php
+++ b/single-chasse.php
@@ -14,6 +14,7 @@ if (!$chasse_id) {
 
 verifier_ou_recalculer_statut_chasse($chasse_id);
 verifier_et_synchroniser_cache_enigmes_si_autorise($chasse_id);
+verifier_ou_mettre_a_jour_cache_complet($chasse_id);
 
 $edition_active = utilisateur_peut_modifier_post($chasse_id);
 $user_id = get_current_user_id();

--- a/single-enigme.php
+++ b/single-enigme.php
@@ -26,9 +26,12 @@ if (!enigme_est_visible_pour($user_id, $enigme_id)) {
 
 // 🔹 Mode édition auto
 $edition_active = utilisateur_peut_modifier_post($enigme_id);
+verifier_ou_mettre_a_jour_cache_complet($enigme_id);
+$enigme_complete = (bool) get_field('enigme_cache_complet', $enigme_id);
 if (
   $edition_active &&
   current_user_can('organisateur_creation') &&
+  !$enigme_complete &&
   !isset($_GET['edition'])
 ) {
   wp_redirect(add_query_arg('edition', 'open', get_permalink()));

--- a/single-organisateur.php
+++ b/single-organisateur.php
@@ -18,6 +18,12 @@ acf_form_head(); // <-- doit être ici, AVANT get_header() !
 
 global $post;
 $organisateur_id = $post->ID;
+$user_id = get_current_user_id();
+$roles = (array) wp_get_current_user()->roles;
+$is_owner = $user_id && (int) get_post_field('post_author', $organisateur_id) === $user_id;
+if ($is_owner && in_array('organisateur_creation', $roles, true)) {
+    verifier_ou_mettre_a_jour_cache_complet($organisateur_id);
+}
 $peut_modifier = utilisateur_peut_modifier_post($organisateur_id);
 $image_logo = get_the_post_thumbnail_url($organisateur_id, 'medium_large');
 $nom_organisateur = get_the_title($organisateur_id);

--- a/template-parts/organisateur/organisateur-edition-main.php
+++ b/template-parts/organisateur/organisateur-edition-main.php
@@ -12,7 +12,8 @@ $roles = (array) $current_user->roles;
 $profil_expanded = array_intersect($roles, ['organisateur_creation', 'abonne']);
 $profil_expanded = !empty($profil_expanded);
 $infos_expanded = !$profil_expanded;
-$edition_active = in_array('organisateur_creation', $roles);
+$cache_complet  = get_field('organisateur_cache_complet', $organisateur_id);
+$edition_active = in_array('organisateur_creation', $roles) && !$cache_complet;
 
 // Post
 $titre        = get_post_field('post_title', $organisateur_id);
@@ -37,8 +38,8 @@ $bic_vide  = empty($coordonnees['bic']);
 $classe_vide_coordonnees = ($iban_vide || $bic_vide) ? 'champ-vide' : '';
 ?>
 
-<?php if ($edition_active && $peut_modifier) : ?>
-  <section class="panneau-organisateur edition-panel edition-panel-organisateur edition-panel-modal edition-active" aria-hidden="false">
+<?php if ($peut_modifier) : ?>
+  <section class="panneau-organisateur edition-panel edition-panel-organisateur edition-panel-modal<?php echo $edition_active ? ' edition-active' : ''; ?>" aria-hidden="<?php echo $edition_active ? 'false' : 'true'; ?>">
 
     <div class="edition-panel-header">
       <h2><i class="fa-solid fa-sliders"></i> Paramètres organisateur</h2>


### PR DESCRIPTION
## Summary
- verify and update completion cache when single pages load
- disable panel auto-open if the CPT is complete

## Testing
- `git status --short`
- `php -l inc/statut-functions.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858c92bea348332a5d7bf5127c496c3