### PR TITLE
Fix PHP syntax error in edition-core

### DIFF
--- a/inc/edition/edition-core.php
+++ b/inc/edition/edition-core.php
@@ -430,9 +430,8 @@ function injection_classe_edition_active(array $classes): array
   // === CHASSE ===
   if (
     $post->post_type === 'chasse' &&
-
     in_array('organisateur_creation', $roles, true)
-
+  ) {
     $organisateur_id = get_organisateur_from_chasse($post->ID);
     $associes = get_field('utilisateurs_associes', $organisateur_id, false);
     $associes = is_array($associes) ? array_map('strval', $associes) : [];


### PR DESCRIPTION
## Summary
- close conditional block for `chasse` check in `edition-core.php`

## Testing
- `php -l inc/edition/edition-core.php` *(fails: `php` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6858d3cf8bf08332a141e1f38560c725