### PR TITLE
Uniformiser les panneaux latéraux

### DIFF
--- a/assets/css/edition.css
+++ b/assets/css/edition.css
@@ -746,8 +746,18 @@ body.panneau-ouvert::before {
   z-index: 9998;
 }
 
+
 .panneau-lateral__contenu {
   padding: 2rem 2rem 2rem 2.5rem;
+}
+
+/* Alignement commun des headers dans les panneaux */
+.panneau-lateral__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1rem;
+  border-bottom: 1px solid var(--color-editor-border);
 }
 
 .panneau-lateral__header h2 {
@@ -763,7 +773,19 @@ body.panneau-ouvert::before {
 
 /* 🧭 Bouton de fermeture */
 .panneau-fermer {
-  margin-bottom: 0.5rem;
+  background: none;
+  border: none;
+  font-size: 1.25rem;
+  color: var(--color-editor-text-muted);
+  cursor: pointer;
+  padding: 0.25rem;
+  line-height: 1;
+  transition: color 0.2s ease;
+  opacity: 0.75;
+}
+
+.panneau-fermer:hover {
+  opacity: 1;
 }
 
 /* 🧭 Liste sans puces */
@@ -841,7 +863,7 @@ body.panneau-ouvert::before {
 
 .panneau-lateral-large {
   width: 100%;
-  max-width: 900px;
+  max-width: 1000px;
 }
 
 .zone-chasses.masque,

--- a/template-parts/chasse/panneaux/chasse-edition-description.php
+++ b/template-parts/chasse/panneaux/chasse-edition-description.php
@@ -12,13 +12,13 @@ $chasse_id = $args['chasse_id'] ?? null;
 if (!$chasse_id || get_post_type($chasse_id) !== 'chasse') return;
 ?>
 
-<div id="panneau-description-chasse" class="panneau-lateral-liens panneau-lateral-large" aria-hidden="true">
+<div id="panneau-description-chasse" class="panneau-lateral-liens panneau-lateral-large" aria-hidden="true" role="dialog">
   <div class="panneau-lateral__contenu">
 
-    <div class="panneau-lateral__header">
-      <button type="button" class="panneau-fermer" aria-label="Fermer le panneau">✖</button>
+    <header class="panneau-lateral__header">
       <h2>Modifier la description de la chasse</h2>
-    </div>
+      <button type="button" class="panneau-fermer" aria-label="Fermer le panneau">✖</button>
+    </header>
 
     <?php
     acf_form([

--- a/template-parts/chasse/panneaux/chasse-edition-liens.php
+++ b/template-parts/chasse/panneaux/chasse-edition-liens.php
@@ -47,14 +47,13 @@ foreach ($liens as $entree) {
 }
 ?>
 
-<div id="panneau-liens-chasse" class="panneau-lateral-liens" aria-hidden="true">
+<div id="panneau-liens-chasse" class="panneau-lateral-liens" aria-hidden="true" role="dialog">
   <div class="panneau-lateral__contenu">
 
-    <div class="panneau-lateral__header">
-        <button type="button" class="panneau-fermer" aria-label="Fermer le panneau">✖</button>
+    <header class="panneau-lateral__header">
       <h2>Configurer les liens de cette chasse</h2>
-      
-    </div>
+      <button type="button" class="panneau-fermer" aria-label="Fermer le panneau">✖</button>
+    </header>
 
     <form id="formulaire-liens-chasse"
           data-post-id="<?= esc_attr($chasse_id); ?>"

--- a/template-parts/chasse/panneaux/chasse-edition-recompense.php
+++ b/template-parts/chasse/panneaux/chasse-edition-recompense.php
@@ -9,13 +9,13 @@ $valeur_recompense = $caracteristiques['chasse_infos_recompense_valeur'] ?? '';
 ?>
 
 
-<div id="panneau-recompense-chasse" class="panneau-lateral-liens panneau-lateral-large" aria-hidden="true">
+<div id="panneau-recompense-chasse" class="panneau-lateral-liens panneau-lateral-large" aria-hidden="true" role="dialog">
   <div class="panneau-lateral__contenu">
 
-    <div class="panneau-lateral__header">
-      <button type="button" class="panneau-fermer" aria-label="Fermer le panneau">✖</button>
+    <header class="panneau-lateral__header">
       <h2>Configurer la récompense</h2>
-    </div>
+      <button type="button" class="panneau-fermer" aria-label="Fermer le panneau">✖</button>
+    </header>
 
     <div class="champ-wrapper" style="display: flex; flex-direction: column; gap: 20px;">
         

--- a/template-parts/enigme/panneaux/enigme-edition-description.php
+++ b/template-parts/enigme/panneaux/enigme-edition-description.php
@@ -11,13 +11,13 @@ $enigme_id = $args['enigme_id'] ?? null;
 if (!$enigme_id || get_post_type($enigme_id) !== 'enigme') return;
 ?>
 
-<div id="panneau-description-enigme" class="panneau-lateral-liens panneau-lateral-large" aria-hidden="true">
+<div id="panneau-description-enigme" class="panneau-lateral-liens panneau-lateral-large" aria-hidden="true" role="dialog">
   <div class="panneau-lateral__contenu">
 
-    <div class="panneau-lateral__header">
-      <button type="button" class="panneau-fermer" aria-label="Fermer le panneau">✖</button>
+    <header class="panneau-lateral__header">
       <h2>Modifier le texte de l’énigme</h2>
-    </div>
+      <button type="button" class="panneau-fermer" aria-label="Fermer le panneau">✖</button>
+    </header>
 
     <?php
     acf_form([

--- a/template-parts/enigme/panneaux/enigme-edition-images.php
+++ b/template-parts/enigme/panneaux/enigme-edition-images.php
@@ -5,12 +5,12 @@ $enigme_id = $args['enigme_id'] ?? null;
 if (!$enigme_id || get_post_type($enigme_id) !== 'enigme') return;
 ?>
 
-<div id="panneau-images-enigme" class="panneau-lateral-liens panneau-lateral-large" aria-hidden="true">
+<div id="panneau-images-enigme" class="panneau-lateral-liens panneau-lateral-large" aria-hidden="true" role="dialog">
   <div class="panneau-lateral__contenu">
-    <div class="panneau-lateral__header">
-      <button type="button" class="panneau-fermer" aria-label="Fermer le panneau">✖</button>
+    <header class="panneau-lateral__header">
       <h2>Modifier les images de l’énigme</h2>
-    </div>
+      <button type="button" class="panneau-fermer" aria-label="Fermer le panneau">✖</button>
+    </header>
 
     <?php
     acf_form([

--- a/template-parts/enigme/panneaux/enigme-edition-solution.php
+++ b/template-parts/enigme/panneaux/enigme-edition-solution.php
@@ -5,13 +5,13 @@ $enigme_id = $args['enigme_id'] ?? null;
 if (!$enigme_id || get_post_type($enigme_id) !== 'enigme') return;
 ?>
 
-<div id="panneau-solution-enigme" class="panneau-lateral-liens panneau-lateral-large" aria-hidden="true">
+<div id="panneau-solution-enigme" class="panneau-lateral-liens panneau-lateral-large" aria-hidden="true" role="dialog">
   <div class="panneau-lateral__contenu">
 
-    <div class="panneau-lateral__header">
-      <button type="button" class="panneau-fermer" aria-label="Fermer le panneau">✖</button>
+    <header class="panneau-lateral__header">
       <h2>Rédiger la solution de cette énigme</h2>
-    </div>
+      <button type="button" class="panneau-fermer" aria-label="Fermer le panneau">✖</button>
+    </header>
 
     <div class="champ-wrapper">
       <?php

--- a/template-parts/enigme/panneaux/enigme-edition-variantes.php
+++ b/template-parts/enigme/panneaux/enigme-edition-variantes.php
@@ -7,13 +7,13 @@ if (!$enigme_id || get_post_type($enigme_id) !== 'enigme') return;
 $variantes = get_field('enigme_reponse_variantes', $enigme_id) ?? [];
 ?>
 
-<div id="panneau-variantes-enigme" class="panneau-lateral-liens panneau-lateral-large" aria-hidden="true">
+<div id="panneau-variantes-enigme" class="panneau-lateral-liens panneau-lateral-large" aria-hidden="true" role="dialog">
   <div class="panneau-lateral__contenu">
 
-    <div class="panneau-lateral__header">
-      <button type="button" class="panneau-fermer" aria-label="Fermer les variantes">✖</button>
+    <header class="panneau-lateral__header">
       <h2>Configurer les variantes de réponse</h2>
-    </div>
+      <button type="button" class="panneau-fermer" aria-label="Fermer les variantes">✖</button>
+    </header>
 
     <?php if (empty($variantes)) : ?>
       <p class="champ-aide champ-variantes-aucune">Aucune variante définie pour l’instant. Commencez à saisir votre première variante ci-dessous.</p>

--- a/template-parts/organisateur/panneaux/organisateur-edition-coordonnees.php
+++ b/template-parts/organisateur/panneaux/organisateur-edition-coordonnees.php
@@ -11,12 +11,12 @@ $iban = $coordonnees['iban'] ?? '';
 $bic  = $coordonnees['bic'] ?? '';
 ?>
 
-<div id="panneau-coordonnees" class="panneau-lateral-liens" aria-hidden="true">
+<div id="panneau-coordonnees" class="panneau-lateral-liens" aria-hidden="true" role="dialog">
     <div class="panneau-lateral__contenu">
-        <div class="panneau-lateral__header">
+        <header class="panneau-lateral__header">
             <h2>Modifier vos coordonnées bancaires</h2>
             <button type="button" class="panneau-fermer" aria-label="Fermer le panneau">✖</button>
-        </div>
+        </header>
     
         <form id="formulaire-coordonnees" data-post-id="<?= esc_attr($organisateur_id); ?>">
             <div class="champ-wrapper">

--- a/template-parts/organisateur/panneaux/organisateur-edition-description.php
+++ b/template-parts/organisateur/panneaux/organisateur-edition-description.php
@@ -5,14 +5,14 @@ $organisateur_id = $args['organisateur_id'] ?? null;
 
 ?>
 
-<div id="panneau-description" class="panneau-lateral-liens panneau-lateral-large" aria-hidden="true">
+<div id="panneau-description" class="panneau-lateral-liens panneau-lateral-large" aria-hidden="true" role="dialog">
     <div class="panneau-lateral__contenu">
 
-        <div class="panneau-lateral__header">
-            <button type="button" class="panneau-fermer" aria-label="Fermer le panneau">✖</button>
+        <header class="panneau-lateral__header">
             <h2>Modifier votre présentation</h2>
-            
-        </div>
+            <button type="button" class="panneau-fermer" aria-label="Fermer le panneau">✖</button>
+
+        </header>
         <?php
         acf_form([
             'post_id'             => $organisateur_id,

--- a/template-parts/organisateur/panneaux/organisateur-edition-liens.php
+++ b/template-parts/organisateur/panneaux/organisateur-edition-liens.php
@@ -23,13 +23,13 @@ if (is_array($liens_publics)) {
 }
 
     if (!empty($types_disponibles)) : ?>
-        <div id="panneau-liens-publics" class="panneau-lateral-liens" aria-hidden="true">
+        <div id="panneau-liens-publics" class="panneau-lateral-liens" aria-hidden="true" role="dialog">
             <div class="panneau-lateral__contenu">
 
-                <div class="panneau-lateral__header">
+                <header class="panneau-lateral__header">
                     <h2>Configurer vos liens publics</h2>
                     <button type="button" class="panneau-fermer" aria-label="Fermer le panneau">✖</button>
-                </div>
+                </header>
 
                 <form id="formulaire-liens-publics"
                       data-post-id="<?= esc_attr($organisateur_id); ?>"


### PR DESCRIPTION
## Summary
- harmonize HTML structure for all edition panels
- style panel headers consistently
- enlarge `panneau-lateral-large` for comfortable text editing

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6858d8eb76d8833284af76bd9d28e469