### PR TITLE
UI update for Enigme cards

### DIFF
--- a/assets/css/cartes.css
+++ b/assets/css/cartes.css
@@ -65,11 +65,42 @@
   text-align: center;
 }
 
+/* Ajustements pour les cartes énigme */
+.carte-enigme .carte-core {
+  display: flex;
+  flex-direction: column;
+  padding: 0;
+  height: 100%;
+}
+
 .carte-enigme-image,
 .carte-ligne__image {
   width: 100%;
   height: 180px;
   overflow: hidden;
+}
+
+.carte-enigme-image {
+  position: relative;
+  flex: 2;
+}
+
+.carte-enigme-cta {
+  position: absolute;
+  bottom: 10px;
+  left: 0;
+  right: 0;
+  display: flex;
+  justify-content: center;
+}
+
+.carte-enigme h3 {
+  margin: 0;
+  padding: 0.5rem 1rem;
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .carte-enigme-image img,

--- a/template-parts/enigme/chasse-partial-boucle-enigmes.php
+++ b/template-parts/enigme/chasse-partial-boucle-enigmes.php
@@ -39,10 +39,11 @@ $has_enigmes = !empty($posts_visibles);
       <div class="carte-core">
         <div class="carte-enigme-image">
           <?php afficher_picture_vignette_enigme($enigme_id, 'Vignette de l’énigme'); ?>
+          <div class="carte-enigme-cta">
+            <?php render_cta_enigme($cta, $enigme_id); ?>
+          </div>
         </div>
         <h3><?= esc_html($titre); ?></h3>
-
-        <?php render_cta_enigme($cta, $enigme_id); ?>
       </div>
     </article>
 


### PR DESCRIPTION
## Summary
- overlay CTA button on enigme images
- make image fill two thirds of card with CTA on top and title underneath

## Testing
- `php -l template-parts/enigme/chasse-partial-boucle-enigmes.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6858dca02c688332b5acc34291fab391