### PR TITLE
Add headers to edition panels

### DIFF
--- a/template-parts/chasse/chasse-edition-main.php
+++ b/template-parts/chasse/chasse-edition-main.php
@@ -38,7 +38,7 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
     <div id="erreur-global" style="display:none; background:red; color:white; padding:5px; text-align:center; font-size:0.9em;"></div>
 
     <div class="edition-panel-header">
-      <h2><i class="fa-solid fa-sliders"></i> Paramètres de la chasse</h2>
+      <h2><i class="fa-solid fa-sliders"></i> Paramètres</h2>
       <button type="button" class="panneau-fermer" aria-label="Fermer les paramètres">✖</button>
     </div>
 
@@ -51,6 +51,9 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
 
     <div id="chasse-tab-param" class="edition-tab-content active">
       <i class="fa-solid fa-sliders tab-watermark" aria-hidden="true"></i>
+      <div class="edition-panel-header">
+        <h2><i class="fa-solid fa-sliders"></i> Paramètres</h2>
+      </div>
       <div class="edition-panel-body">
 
       <div class="edition-panel-section edition-panel-section-ligne">
@@ -270,16 +273,25 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
 
     <div id="chasse-tab-stats" class="edition-tab-content" style="display:none;">
       <i class="fa-solid fa-chart-column tab-watermark" aria-hidden="true"></i>
+      <div class="edition-panel-header">
+        <h2><i class="fa-solid fa-chart-column"></i> Statistiques</h2>
+      </div>
       <p class="edition-placeholder">La section « Statistiques » sera bientôt disponible.</p>
     </div>
 
     <div id="chasse-tab-classement" class="edition-tab-content" style="display:none;">
       <i class="fa-solid fa-ranking-star tab-watermark" aria-hidden="true"></i>
+      <div class="edition-panel-header">
+        <h2><i class="fa-solid fa-ranking-star"></i> Classement</h2>
+      </div>
       <p class="edition-placeholder">La section « Classement » sera bientôt disponible.</p>
     </div>
 
     <div id="chasse-tab-indices" class="edition-tab-content" style="display:none;">
       <i class="fa-regular fa-lightbulb tab-watermark" aria-hidden="true"></i>
+      <div class="edition-panel-header">
+        <h2><i class="fa-regular fa-lightbulb"></i> Indices</h2>
+      </div>
       <p class="edition-placeholder">La section « Indices » sera bientôt disponible.</p>
     </div>
 

--- a/template-parts/enigme/enigme-edition-main.php
+++ b/template-parts/enigme/enigme-edition-main.php
@@ -65,7 +65,7 @@ $has_variantes = ($nb_variantes > 0);
       style="display:none; background:red; color:white; padding:5px; text-align:center; font-size:0.9em;"></div>
 
     <div class="edition-panel-header">
-      <h2><i class="fa-solid fa-sliders"></i> Paramètres de l'énigme</h2>
+      <h2><i class="fa-solid fa-sliders"></i> Paramètres</h2>
 
       <!-- ✅ Ajout du champ Style ici -->
       <div class="champ-enigme champ-style" data-champ="enigme_style_affichage" data-cpt="enigme" data-post-id="<?= esc_attr($enigme_id); ?>" style="margin-top: 8px;">
@@ -89,6 +89,9 @@ $has_variantes = ($nb_variantes > 0);
 
 <div id="enigme-tab-param" class="edition-tab-content active">
       <i class="fa-solid fa-sliders tab-watermark" aria-hidden="true"></i>
+      <div class="edition-panel-header">
+        <h2><i class="fa-solid fa-sliders"></i> Paramètres</h2>
+      </div>
       <div class="edition-panel-body edition-panel-section">
       <div class="resume-blocs-grid deux-col-wrapper">
         <div class="resume-bloc resume-obligatoire deux-col-bloc">
@@ -386,11 +389,17 @@ $has_variantes = ($nb_variantes > 0);
 
     <div id="enigme-tab-stats" class="edition-tab-content" style="display:none;">
       <i class="fa-solid fa-chart-column tab-watermark" aria-hidden="true"></i>
+      <div class="edition-panel-header">
+        <h2><i class="fa-solid fa-chart-column"></i> Statistiques</h2>
+      </div>
       <p class="edition-placeholder">La section « Statistiques » sera bientôt disponible.</p>
     </div>
 
 <div id="enigme-tab-soumission" class="edition-tab-content" style="display:none;">
   <i class="fa-solid fa-paper-plane tab-watermark" aria-hidden="true"></i>
+  <div class="edition-panel-header">
+    <h2><i class="fa-solid fa-paper-plane"></i> Soumission</h2>
+  </div>
 <?php
   $page_tentatives = max(1, intval($_GET['page_tentatives'] ?? 1));
   $par_page = 25;
@@ -431,11 +440,17 @@ $has_variantes = ($nb_variantes > 0);
 
 <div id="enigme-tab-indices" class="edition-tab-content" style="display:none;">
   <i class="fa-regular fa-lightbulb tab-watermark" aria-hidden="true"></i>
+  <div class="edition-panel-header">
+    <h2><i class="fa-regular fa-lightbulb"></i> Indices</h2>
+  </div>
   <p class="edition-placeholder">La section « Indices » sera bientôt disponible.</p>
 </div>
 
 <div id="enigme-tab-solution" class="edition-tab-content" style="display:none;">
   <i class="fa-solid fa-key tab-watermark" aria-hidden="true"></i>
+  <div class="edition-panel-header">
+    <h2><i class="fa-solid fa-key"></i> Solution</h2>
+  </div>
 
             <fieldset class="groupe-champ champ-groupe-solution">
               <legend>Publication de la solution</legend>

--- a/template-parts/organisateur/organisateur-edition-main.php
+++ b/template-parts/organisateur/organisateur-edition-main.php
@@ -42,7 +42,7 @@ $classe_vide_coordonnees = ($iban_vide || $bic_vide) ? 'champ-vide' : '';
   <section class="panneau-organisateur edition-panel edition-panel-organisateur edition-panel-modal<?php echo $edition_active ? ' edition-active' : ''; ?>" aria-hidden="<?php echo $edition_active ? 'false' : 'true'; ?>">
 
     <div class="edition-panel-header">
-      <h2><i class="fa-solid fa-sliders"></i> Paramètres organisateur</h2>
+      <h2><i class="fa-solid fa-sliders"></i> Paramètres</h2>
       <button type="button" class="panneau-fermer" aria-label="Fermer les paramètres organisateur">
         ✖
       </button>
@@ -56,6 +56,9 @@ $classe_vide_coordonnees = ($iban_vide || $bic_vide) ? 'champ-vide' : '';
 
     <div id="organisateur-tab-param" class="edition-tab-content active">
       <i class="fa-solid fa-sliders tab-watermark" aria-hidden="true"></i>
+      <div class="edition-panel-header">
+        <h2><i class="fa-solid fa-sliders"></i> Paramètres</h2>
+      </div>
       <div class="edition-panel-body">
       <div class="edition-panel-section edition-panel-section-ligne">
         <h3 class="section-title">
@@ -210,11 +213,17 @@ $classe_vide_coordonnees = ($iban_vide || $bic_vide) ? 'champ-vide' : '';
 
       <div id="organisateur-tab-stats" class="edition-tab-content" style="display:none;">
         <i class="fa-solid fa-chart-column tab-watermark" aria-hidden="true"></i>
+        <div class="edition-panel-header">
+          <h2><i class="fa-solid fa-chart-column"></i> Statistiques</h2>
+        </div>
         <p class="edition-placeholder">La section « Statistiques » sera bientôt disponible.</p>
       </div>
 
       <div id="organisateur-tab-revenus" class="edition-tab-content" style="display:none;">
         <i class="fa-solid fa-coins tab-watermark" aria-hidden="true"></i>
+        <div class="edition-panel-header">
+          <h2><i class="fa-solid fa-coins"></i> Revenus</h2>
+        </div>
         <p class="edition-placeholder">La section « Revenus » sera bientôt disponible.</p>
       </div>
 


### PR DESCRIPTION
## Summary
- unify main panel headers to use a common text
- add header sections to each tab in edition panels

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6858dea5ea708332a51346a429a1aaa6