### PR TITLE
Align subtitle field with completion icon

### DIFF
--- a/assets/css/edition.css
+++ b/assets/css/edition.css
@@ -264,12 +264,13 @@ body.edition-active-enigme .single-enigme-main .champ-modifier {
   display: inline-flex;
 }
 
-body.edition-active-enigme .single-enigme-main [data-champ="enigme_visuel_legende"] {
+/* Harmonisation de l'alignement pour le champ sous-titre dans le panneau Énigme */
+.single-enigme-main [data-champ="enigme_visuel_legende"] {
   display: inline-flex;
   align-items: center;
 }
 
-body.edition-active-enigme .single-enigme-main [data-champ="enigme_visuel_legende"] .champ-affichage {
+.single-enigme-main [data-champ="enigme_visuel_legende"] .champ-affichage {
   padding-left: 5px;
 }
 


### PR DESCRIPTION
## Summary
- adjust CSS so the subtitle field (`enigme_visuel_legende`) is always displayed in `inline-flex`
- keep padding so text aligns nicely with the completion icon

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6858e230d7d0833295b8cba3949bfb32