### PR TITLE
Ajout bouton validation de chasse

### DIFF
--- a/assets/css/layout.css
+++ b/assets/css/layout.css
@@ -476,3 +476,14 @@ footer .ast-footer-widget a {
     padding-inline: 10px;
   }
 }
+.bandeau-info-chasse {
+  background: var(--color-secondary);
+  color: var(--color-text-fond-clair);
+  text-align: center;
+  padding: 0.25rem 1rem;
+  font-size: 0.9rem;
+}
+.bandeau-info-chasse form {
+  display: inline-block;
+  margin-left: 1rem;
+}

--- a/assets/js/validation-chasse.js
+++ b/assets/js/validation-chasse.js
@@ -1,0 +1,9 @@
+document.addEventListener('DOMContentLoaded', () => {
+  document.addEventListener('click', (e) => {
+    const btn = e.target.closest('.bouton-validation-chasse');
+    if (!btn) return;
+    if (typeof window.onValiderChasseClick === 'function') {
+      window.onValiderChasseClick(btn);
+    }
+  });
+});

--- a/inc/layout-functions.php
+++ b/inc/layout-functions.php
@@ -139,6 +139,14 @@ function charger_scripts_personnalises() {
       filemtime(get_stylesheet_directory() . '/assets/js/encodage-morse.js'),
       true
     );
+
+    wp_enqueue_script(
+      'validation-chasse',
+      $theme_dir . 'validation-chasse.js',
+      [],
+      filemtime(get_stylesheet_directory() . '/assets/js/validation-chasse.js'),
+      true
+    );
 }
 // ✅ Ajout des scripts au chargement de WordPress
 add_action('wp_enqueue_scripts', 'charger_scripts_personnalises');
@@ -331,3 +339,35 @@ function limiter_texte_avec_toggle($texte, $limite = 200, $label_plus = 'Lire la
     <?php
     return ob_get_clean();
 }
+/**
+ * Affiche un bandeau d'information global invitant l'organisateur
+ * à valider sa chasse lorsque toutes les conditions sont réunies.
+ *
+ * @hook astra_header_after
+ */
+function afficher_bandeau_validation_chasse_global() {
+    if (!is_user_logged_in()) {
+        return;
+    }
+
+    $user_id = get_current_user_id();
+    if (!$user_id) {
+        return;
+    }
+
+    if (!function_exists('trouver_chasse_a_valider')) {
+        return;
+    }
+
+    $chasse_id = trouver_chasse_a_valider($user_id);
+    if (!$chasse_id) {
+        return;
+    }
+
+    $titre = get_the_title($chasse_id);
+    echo '<div class="bandeau-info-chasse">';
+    echo '<span>Votre chasse : ' . esc_html($titre) . '</span>';
+    echo render_form_validation_chasse($chasse_id);
+    echo '</div>';
+}
+add_action('astra_header_after', 'afficher_bandeau_validation_chasse_global');

--- a/single-chasse.php
+++ b/single-chasse.php
@@ -61,6 +61,14 @@ $statut = get_field('champs_caches')['chasse_cache_statut'] ?? 'revision';
 $nb_joueurs = 0;
 
 get_header();
+
+$can_validate = peut_valider_chasse($chasse_id, $user_id);
+if ($can_validate) {
+    echo '<div class="cta-chasse">';
+    echo '<p>Lorsque vous avez finalisé votre chasse, demandez sa validation :</p>';
+    echo render_form_validation_chasse($chasse_id);
+    echo '</div>';
+}
 ?>
 
 <div class="ast-container">

--- a/templates/page-traitement-validation-chasse.php
+++ b/templates/page-traitement-validation-chasse.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * Template Name: Traitement Validation Chasse
+ */
+
+defined('ABSPATH') || exit;
+
+require_once get_theme_file_path('inc/chasse-functions.php');
+require_once get_theme_file_path('inc/statut-functions.php');
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    wp_redirect(home_url());
+    exit;
+}
+
+$user_id = get_current_user_id();
+$chasse_id = isset($_POST['chasse_id']) ? intval($_POST['chasse_id']) : 0;
+
+if (!$user_id || !$chasse_id || get_post_type($chasse_id) !== 'chasse') {
+    wp_redirect(home_url());
+    exit;
+}
+
+if (
+    !isset($_POST['validation_chasse_nonce']) ||
+    !wp_verify_nonce($_POST['validation_chasse_nonce'], 'validation_chasse_' . $chasse_id)
+) {
+    wp_die('Vérification de sécurité échouée.');
+}
+
+if (!peut_valider_chasse($chasse_id, $user_id)) {
+    wp_die('Conditions non remplies.');
+}
+
+forcer_statut_apres_acf($chasse_id, 'en_attente');
+
+wp_redirect(add_query_arg('validation_demandee', '1', get_permalink($chasse_id)));
+exit;


### PR DESCRIPTION
## Summary
- ajouter la logique PHP `peut_valider_chasse()` pour vérifier si la chasse peut être soumise
- générer un formulaire de demande de validation et bandeau global
- afficher le bloc de validation en haut des pages chasse
- nouvelle page de traitement `traitement-validation-chasse`
- charger un script JS dédié et sa feuille de style

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6858ef5e446c8332bd77bdbad69320b5