### PR TITLE
Update banner text in validation panel

### DIFF
--- a/inc/layout-functions.php
+++ b/inc/layout-functions.php
@@ -365,9 +365,13 @@ function afficher_bandeau_validation_chasse_global() {
     }
 
     $titre = get_the_title($chasse_id);
+    $lien  = get_permalink($chasse_id);
     echo '<div class="bandeau-info-chasse">';
-    echo '<span>Votre chasse : ' . esc_html($titre) . '</span>';
-    echo render_form_validation_chasse($chasse_id);
+    printf(
+        '<span>Votre chasse : <a href="%s">%s</a> est en cours d\'édition</span>',
+        esc_url($lien),
+        esc_html($titre)
+    );
     echo '</div>';
 }
 add_action('astra_header_after', 'afficher_bandeau_validation_chasse_global');


### PR DESCRIPTION
## Summary
- adjust the global banner message for hunt validation
- remove the validation CTA button
- link the hunt title to its page

## Testing
- `php -l inc/layout-functions.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858f4a696388332b9825897f8a7148e