### PR TITLE
Add development card for admin

### DIFF
--- a/assets/js/developpement-card.js
+++ b/assets/js/developpement-card.js
@@ -1,0 +1,27 @@
+document.addEventListener("DOMContentLoaded", function() {
+    const btn = document.getElementById("afficher-champs-acf");
+    if (!btn) return;
+
+    btn.addEventListener("click", function(e) {
+        e.preventDefault();
+        fetch(ajax_object.ajax_url, {
+            method: "POST",
+            headers: {
+                "Content-Type": "application/x-www-form-urlencoded; charset=UTF-8"
+            },
+            body: "action=recuperer_details_acf"
+        })
+        .then(resp => resp.json())
+        .then(data => {
+            if (data.success) {
+                alert(data.data);
+            } else {
+                alert("Erreur : " + data.data);
+            }
+        })
+        .catch(err => {
+            console.error(err);
+            alert("Erreur AJAX");
+        });
+    });
+});

--- a/inc/admin-functions.php
+++ b/inc/admin-functions.php
@@ -1246,3 +1246,43 @@ add_action('admin_notices', function() {
 });
 
 */
+
+// =============================================
+// AJAX : récupérer les détails des groupes ACF
+// =============================================
+function recuperer_details_acf() {
+    if (!current_user_can('administrator')) {
+        wp_send_json_error('Non autorisé');
+    }
+
+    $ids = [27, 9, 657];
+    ob_start();
+    foreach ($ids as $id) {
+        acf_inspect_field_group($id);
+        echo "\n";
+    }
+    $output = ob_get_clean();
+    $output = wp_strip_all_tags($output);
+    wp_send_json_success($output);
+}
+add_action('wp_ajax_recuperer_details_acf', 'recuperer_details_acf');
+
+
+/**
+ * Charge le script de la carte Développement sur la page Mon Compte
+ */
+function charger_script_developpement_card() {
+    if (is_page('mon-compte') && current_user_can('administrator')) {
+        wp_enqueue_script(
+            'developpement-card',
+            get_stylesheet_directory_uri() . '/assets/js/developpement-card.js',
+            [],
+            filemtime(get_stylesheet_directory() . '/assets/js/developpement-card.js'),
+            true
+        );
+        wp_localize_script('developpement-card', 'ajax_object', [
+            'ajax_url' => admin_url('admin-ajax.php')
+        ]);
+    }
+}
+add_action('wp_enqueue_scripts', 'charger_script_developpement_card');

--- a/woocommerce/myaccount/admin.php
+++ b/woocommerce/myaccount/admin.php
@@ -166,6 +166,15 @@ $taux_conversion = get_taux_conversion_actuel();
                 <?php endif; ?>
             </div>
         </div>
+    <div class="dashboard-card">
+        <div class="dashboard-card-header">
+            <i class="fas fa-tools"></i>
+            <h3>Développement</h3>
+        </div>
+        <div class="stats-content">
+            <button id="afficher-champs-acf" class="bouton-secondaire">Afficher les champs ACF</button>
+        </div>
+    </div>
     </div>
 <?php
 if (is_page('mon-compte') && current_user_can('administrator')) {


### PR DESCRIPTION
## Summary
- add a JS helper to call AJAX for displaying ACF info
- provide AJAX endpoint and script loader in admin functions
- show a new "Développement" card on the admin dashboard

## Testing
- `php -l inc/admin-functions.php` *(fails: `php` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6858f72e6560833282916c3284dc44bb