### PR TITLE
Improve ACF info display for admins

### DIFF
--- a/assets/js/developpement-card.js
+++ b/assets/js/developpement-card.js
@@ -1,6 +1,9 @@
 document.addEventListener("DOMContentLoaded", function() {
     const btn = document.getElementById("afficher-champs-acf");
-    if (!btn) return;
+    const container = document.getElementById("acf-fields-container");
+    const output = document.getElementById("acf-fields-output");
+
+    if (!btn || !container || !output) return;
 
     btn.addEventListener("click", function(e) {
         e.preventDefault();
@@ -14,7 +17,8 @@ document.addEventListener("DOMContentLoaded", function() {
         .then(resp => resp.json())
         .then(data => {
             if (data.success) {
-                alert(data.data);
+                output.value = data.data;
+                container.style.display = "block";
             } else {
                 alert("Erreur : " + data.data);
             }

--- a/woocommerce/myaccount/admin.php
+++ b/woocommerce/myaccount/admin.php
@@ -173,6 +173,9 @@ $taux_conversion = get_taux_conversion_actuel();
         </div>
         <div class="stats-content">
             <button id="afficher-champs-acf" class="bouton-secondaire">Afficher les champs ACF</button>
+            <div id="acf-fields-container" style="display:none;margin-top:10px;">
+                <textarea id="acf-fields-output" style="width:100%;height:300px;" readonly></textarea>
+            </div>
         </div>
     </div>
     </div>


### PR DESCRIPTION
## Summary
- show ACF data in a textarea below the button
- update JS to fill the textarea with AJAX results instead of `alert`

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859012201dc833292a105f454b246eb