### PR TITLE
Add confirmation modal before validating hunts

### DIFF
--- a/assets/css/organisateurs.css
+++ b/assets/css/organisateurs.css
@@ -258,6 +258,28 @@
   border-color: var(--color-accent, #ffc400);
   color: #fff;
 }
+
+/* ========== 🟢 MODAL CONFIRMATION VALIDATION CHASSE ========== */
+.modal-confirmation-validation-chasse {
+  position: fixed;
+  z-index: 9999;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.65);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  animation: fadeIn 0.3s ease-in-out;
+}
+.modal-confirmation-validation-chasse label {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  margin-top: 1rem;
+}
+.modal-confirmation-validation-chasse input[type="checkbox"] {
+  transform: scale(1.2);
+  margin-top: 2px;
+}
 .modal-contenu button.header-bouton-edition {
     color: #ffffff;
     background-color: var(--color-background, #ffc400);;

--- a/assets/js/validation-chasse.js
+++ b/assets/js/validation-chasse.js
@@ -1,9 +1,61 @@
+/**
+ * Gestion du bouton "Valider ma chasse".
+ * Une fenêtre de confirmation est affichée avant l'envoi réel du formulaire.
+ */
+
 document.addEventListener('DOMContentLoaded', () => {
   document.addEventListener('click', (e) => {
     const btn = e.target.closest('.bouton-validation-chasse');
     if (!btn) return;
-    if (typeof window.onValiderChasseClick === 'function') {
-      window.onValiderChasseClick(btn);
-    }
+
+    e.preventDefault();
+    const form = btn.closest('form');
+    if (!form) return;
+
+    ouvrirModalConfirmation(form);
   });
 });
+
+function ouvrirModalConfirmation(form) {
+  // Supprimer toute ancienne instance pour éviter les doublons
+  document.querySelector('.modal-confirmation-validation-chasse')?.remove();
+
+  const modal = document.createElement('div');
+  modal.className = 'modal-confirmation-validation-chasse';
+  modal.innerHTML = `
+    <div class="modal-contenu">
+      <button class="modal-close-top" aria-label="Fermer">&times;</button>
+      <p>
+        ⚠️ <strong>En cochant cette case, je certifie avoir finalisé la création de cette chasse et de toutes ses énigmes.</strong><br>
+        📌 <strong>Une fois la demande envoyée, aucune modification ne sera possible.</strong>
+      </p>
+      <label>
+        <input type="checkbox" id="confirm-validation"> Je certifie avoir finalisé la création de cette chasse et de toutes ses énigmes.
+      </label>
+      <div class="boutons-modal">
+        <button class="bouton-cta confirmer-envoi" disabled>Confirmer l'envoi de la demande</button>
+      </div>
+    </div>`;
+
+  document.body.appendChild(modal);
+
+  const checkbox = modal.querySelector('#confirm-validation');
+  const confirmBtn = modal.querySelector('.confirmer-envoi');
+  const closeBtn = modal.querySelector('.modal-close-top');
+
+  checkbox.addEventListener('change', () => {
+    confirmBtn.disabled = !checkbox.checked;
+  });
+
+  const fermer = () => modal.remove();
+  closeBtn.addEventListener('click', fermer);
+  modal.addEventListener('click', (e) => {
+    if (e.target === modal) fermer();
+  });
+
+  confirmBtn.addEventListener('click', () => {
+    confirmBtn.disabled = true;
+    fermer();
+    form.submit();
+  });
+}

--- a/single-chasse.php
+++ b/single-chasse.php
@@ -63,11 +63,15 @@ $nb_joueurs = 0;
 get_header();
 
 $can_validate = peut_valider_chasse($chasse_id, $user_id);
+$validation_envoyee = !empty($_GET['validation_demandee']);
 if ($can_validate) {
     echo '<div class="cta-chasse">';
     echo '<p>Lorsque vous avez finalisé votre chasse, demandez sa validation :</p>';
     echo render_form_validation_chasse($chasse_id);
     echo '</div>';
+}
+if ($validation_envoyee) {
+    echo '<p class="message-succes">✅ Votre demande de validation a bien été envoyée. Elle sera traitée par l’équipe.</p>';
 }
 ?>
 


### PR DESCRIPTION
## Summary
- show a confirmation modal when clicking "Valider ma chasse"
- style the confirmation modal
- display a success message after validation request

## Testing
- `php -l single-chasse.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685902cbd8988332af0ce4516d9d5c36