### PR TITLE
Set fallback hero image on organizer page

### DIFF
--- a/templates/page-devenir-organisateur.php
+++ b/templates/page-devenir-organisateur.php
@@ -35,6 +35,9 @@ $organisateur_id = get_organisateur_from_user($user_id);
 // 👉 maintenant que le CPT existe (ou pas), on peut rediriger
 rediriger_selon_etat_organisateur();
 
+// Image par défaut au cas où aucune miniature n'est définie
+$image_url = '';
+
 if (has_post_thumbnail()) {
   $image_url = get_the_post_thumbnail_url(null, 'full'); // ou 'large' si besoin
 }


### PR DESCRIPTION
## Summary
- define `$image_url` before trying to display the hero background
- keep the featured image logic for overwriting the URL

## Testing
- `php -l templates/page-devenir-organisateur.php` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685906d95c4c83328f5ec99a7f6cff65