### PR TITLE
Display hierarchical list of organiser's hunts

### DIFF
--- a/inc/organisateur-functions.php
+++ b/inc/organisateur-functions.php
@@ -270,3 +270,47 @@ function ajouter_query_var_contact($vars) {
     return $vars;
 }
 add_filter('query_vars', 'ajouter_query_var_contact');
+
+/**
+ * Génére une liste hiérarchique des chasses d'un organisateur.
+ *
+ * Exemple de sortie :
+ * - Organisateur (3 chasses)
+ *   - Chasse 1 (4 énigmes)
+ *   - Chasse 2 (2 énigmes)
+ *
+ * @param int $organisateur_id ID de l'organisateur.
+ * @return string HTML contenant la liste ou chaîne vide si non valide.
+ */
+function generer_liste_chasses_hierarchique($organisateur_id) {
+    if (!$organisateur_id || get_post_type($organisateur_id) !== 'organisateur') {
+        return '';
+    }
+
+    $query = get_chasses_de_organisateur($organisateur_id);
+    $nombre_chasses = $query->found_posts ?? 0;
+
+    $out  = '<ul class="liste-chasses-hierarchique">';
+    $out .= '<li>';
+    $out .= '<a href="' . esc_url(get_permalink($organisateur_id)) . '">' . esc_html(get_the_title($organisateur_id)) . '</a> ';
+    $out .= '(' . sprintf(_n('%d chasse', '%d chasses', $nombre_chasses, 'text-domain'), $nombre_chasses) . ')';
+
+    if ($nombre_chasses > 0) {
+        $out .= '<ul>';
+        foreach ($query->posts as $post) {
+            $chasse_id = $post->ID;
+            $chasse_titre = get_the_title($chasse_id);
+            $nb_enigmes = count(recuperer_enigmes_associees($chasse_id));
+            $out .= '<li>';
+            $out .= '<a href="' . esc_url(get_permalink($chasse_id)) . '">' . esc_html($chasse_titre) . '</a> ';
+            $out .= '(' . sprintf(_n('%d énigme', '%d énigmes', $nb_enigmes, 'text-domain'), $nb_enigmes) . ')';
+            $out .= '</li>';
+        }
+        $out .= '</ul>';
+    }
+
+    $out .= '</li></ul>';
+
+    return $out;
+}
+

--- a/woocommerce/myaccount/organisateur.php
+++ b/woocommerce/myaccount/organisateur.php
@@ -21,6 +21,9 @@ $nombre_chasses = 0;
 if ($organisateur_id) {
     $chasses = get_chasses_de_organisateur($organisateur_id);
     $nombre_chasses = $chasses->found_posts ?? 0;
+    $liste_chasses_organisateur = generer_liste_chasses_hierarchique($organisateur_id);
+} else {
+    $liste_chasses_organisateur = '';
 }
 
 // récupération stats du joueur
@@ -136,7 +139,7 @@ $tableau_contenu = ob_get_clean(); // Récupérer la sortie et l'effacer du buff
         <hr class="separator-line">
     </div>
     <div class="dashboard-grid">
-        <a href="<?php echo esc_url(get_permalink($organisateur_id)); ?>" class="dashboard-card">
+        <div class="dashboard-card">
             <div class="dashboard-card-header">
                 <i class="fas fa-landmark"></i>
                 <h3><?php echo esc_html($organisateur_titre); ?></h3>
@@ -147,7 +150,10 @@ $tableau_contenu = ob_get_clean(); // Récupérer la sortie et l'effacer du buff
                     <?php echo sprintf(_n('%d chasse', '%d chasses', $nombre_chasses, 'text-domain'), $nombre_chasses); ?>
                 </div>
             </div>
-        </a>
+            <div class="stats-content">
+                <?php echo $liste_chasses_organisateur; ?>
+            </div>
+        </div>
         
         <div class="dashboard-card points-card">
             <div class="dashboard-card-header">


### PR DESCRIPTION
## Summary
- add helper to build a nested list of hunts and puzzles
- display this hierarchy in organiser dashboard card

## Testing
- `php -l inc/organisateur-functions.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685917daef788332bd2eb6422a964dce