### PR TITLE
Add completion markers for organiser views

### DIFF
--- a/assets/css/cartes.css
+++ b/assets/css/cartes.css
@@ -166,3 +166,12 @@
   gap: 0.5rem;
   padding: 0 1rem;
 }
+
+/* ========== ✅ Indicateurs de complétion ========== */
+.carte-complete {
+  border: 2px solid var(--color-editor-success);
+}
+
+.carte-incomplete {
+  border: 2px solid var(--color-editor-error);
+}

--- a/template-parts/enigme/chasse-partial-boucle-enigmes.php
+++ b/template-parts/enigme/chasse-partial-boucle-enigmes.php
@@ -34,8 +34,17 @@ $has_enigmes = !empty($posts_visibles);
     $etat_systeme = enigme_get_etat_systeme($enigme_id);
     $statut_utilisateur = enigme_get_statut_utilisateur($enigme_id, $utilisateur_id);
     $cta = get_cta_enigme($enigme_id);
+
+    $roles = wp_get_current_user()->roles;
+    $est_orga = array_intersect($roles, ['organisateur', 'organisateur_creation']);
+    $voir_bordure = !empty($est_orga) && utilisateur_est_organisateur_associe_a_chasse($utilisateur_id, $chasse_id);
+    $classe_completion = '';
+    if ($voir_bordure) {
+      $complet = (bool) get_field('enigme_cache_complet', $enigme_id);
+      $classe_completion = $complet ? 'carte-complete' : 'carte-incomplete';
+    }
     ?>
-    <article class="carte carte-enigme">
+    <article class="carte carte-enigme <?= esc_attr($classe_completion); ?>">
       <div class="carte-core">
         <div class="carte-enigme-image">
           <?php afficher_picture_vignette_enigme($enigme_id, 'Vignette de l’énigme'); ?>

--- a/template-parts/organisateur/organisateur-partial-boucle-chasses.php
+++ b/template-parts/organisateur/organisateur-partial-boucle-chasses.php
@@ -14,8 +14,17 @@ $posts = is_a($query, 'WP_Query') ? $query->posts : (array) $query;
   <?php foreach ($posts as $post) : ?>
     <?php
     $chasse_id = $post->ID;
+    $roles = wp_get_current_user()->roles;
+    $est_orga = array_intersect($roles, ['organisateur', 'organisateur_creation']);
+    $voir_bordure = !empty($est_orga) && utilisateur_est_organisateur_associe_a_chasse(get_current_user_id(), $chasse_id);
+    $classe_completion = '';
+    if ($voir_bordure) {
+      $complet = (bool) get_field('chasse_cache_complet', $chasse_id);
+      $classe_completion = $complet ? 'carte-complete' : 'carte-incomplete';
+    }
     get_template_part('template-parts/organisateur/organisateur-partial-chasse-card', null, [
       'chasse_id' => $chasse_id,
+      'completion_class' => $classe_completion,
     ]);
     ?>
   <?php endforeach; ?>

--- a/template-parts/organisateur/organisateur-partial-chasse-card.php
+++ b/template-parts/organisateur/organisateur-partial-chasse-card.php
@@ -11,6 +11,7 @@ if (!isset($args['chasse_id']) || empty($args['chasse_id'])) {
 }
 
 $chasse_id = $args['chasse_id'];
+$completion_class = $args['completion_class'] ?? '';
 
 // 🔹 Récupération des données de la chasse
 $titre = get_the_title($chasse_id);
@@ -81,7 +82,7 @@ if ($peut_ajouter_enigme) {
 $classe_verrouillee = ($statut === 'Verrouillée') ? 'statut-verrouille' : '';
 ?>
 
-<div class="carte carte-ligne carte-chasse <?php echo esc_attr($classe_statut . ' ' . $classe_verrouillee); ?>">
+<div class="carte carte-ligne carte-chasse <?php echo esc_attr(trim($classe_statut . ' ' . $classe_verrouillee . ' ' . $completion_class)); ?>">
     <?php // ✅ Afficher le menu uniquement s'il y a des actions
     if (!empty($menu_items)) : ?>
         <div class="menu-actions">


### PR DESCRIPTION
## Summary
- highlight completed/incomplete cards for organisers
- enable completion classes on enigme and chasse loops
- support custom class in organiser chasse card template

## Testing
- `php -l template-parts/enigme/chasse-partial-boucle-enigmes.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859268f05c88332a533f3d3a8d8befa