### PR TITLE
Add organiser creation table in admin dashboard

### DIFF
--- a/woocommerce/myaccount/admin.php
+++ b/woocommerce/myaccount/admin.php
@@ -89,10 +89,15 @@ $taux_conversion = get_taux_conversion_actuel();
 
     <!-- 📌 Tuiles en Bas (Accès Rapides) -->
     <div class="dashboard-grid">
-        <a href="<?php echo esc_url(wc_get_account_endpoint_url('orders')); ?>" class="dashboard-card">
-            <span class="icon">📦</span>
-            <h3>Organisateurs</h3>
-        </a>
+        <div class="dashboard-card">
+            <div class="dashboard-card-header">
+                <span class="icon">📦</span>
+                <h3>Organisateurs en création</h3>
+            </div>
+            <div class="stats-content">
+                <?php afficher_tableau_organisateurs_en_creation(); ?>
+            </div>
+        </div>
         <?php if (current_user_can('administrator')) : ?>
             <div class="dashboard-card">
                 <div class="dashboard-card-header">


### PR DESCRIPTION
## Summary
- show table of organiser profiles in creation from admin dashboard
- list associated hunt and number of riddles

## Testing
- `php -l inc/admin-functions.php` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_685929b232388332a6edaf8d3782956b