### PR TITLE
Fix completion detection for default titles

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -59,20 +59,21 @@ require_once $inc_path . 'enigme-functions.php';
 require_once $inc_path . 'user-functions.php';
 require_once $inc_path . 'chasse-functions.php';
 require_once $inc_path . 'gamify-functions.php';
+require_once $inc_path . 'utils/titres.php';
 require_once $inc_path . 'statut-functions.php';
 require_once $inc_path . 'admin-functions.php';
 require_once $inc_path . 'organisateur-functions.php';
 //require_once $inc_path . 'stat-functions.php';
+require_once $inc_path . 'access-functions.php';
+require_once $inc_path . 'relations-functions.php';
+require_once $inc_path . 'layout-functions.php';
+require_once $inc_path . 'utils/liens.php';
+
 require_once $inc_path . 'edition/edition-core.php';
 require_once $inc_path . 'edition/edition-organisateur.php';
 require_once $inc_path . 'edition/edition-chasse.php';
 require_once $inc_path . 'edition/edition-enigme.php';
 require_once $inc_path . 'edition/edition-securite.php';
-
-require_once $inc_path . 'access-functions.php';
-require_once $inc_path . 'relations-functions.php';
-require_once $inc_path . 'layout-functions.php';
-require_once $inc_path . 'utils/liens.php';
 
 
 

--- a/inc/edition/edition-chasse.php
+++ b/inc/edition/edition-chasse.php
@@ -50,7 +50,7 @@ function enqueue_script_chasse_edit()
 
   // Injecte les valeurs par défaut pour JS
   wp_localize_script('champ-init', 'CHP_CHASSE_DEFAUT', [
-    'titre' => 'nouvelle chasse',
+    'titre' => strtolower(TITRE_DEFAUT_CHASSE),
     'image_slug' => 'defaut-chasse-2',
   ]);
 
@@ -130,7 +130,7 @@ function creer_chasse_et_rediriger_si_appel()
   $post_id = wp_insert_post([
     'post_type'   => 'chasse',
     'post_status' => 'pending',
-    'post_title'  => 'Nouvelle chasse',
+    'post_title'  => TITRE_DEFAUT_CHASSE,
     'post_author' => $user_id,
   ]);
 

--- a/inc/edition/edition-enigme.php
+++ b/inc/edition/edition-enigme.php
@@ -63,7 +63,7 @@ function enqueue_script_enigme_edit()
 
   // Localisation JS si besoin (ex : valeurs par défaut)
   wp_localize_script('champ-init', 'CHP_ENIGME_DEFAUT', [
-    'titre' => 'nouvelle énigme',
+    'titre' => strtolower(TITRE_DEFAUT_ENIGME),
     'image_slug' => 'defaut-enigme',
   ]);
 
@@ -101,7 +101,7 @@ function creer_enigme_pour_chasse($chasse_id, $user_id = null)
   $enigme_id = wp_insert_post([
     'post_type'   => 'enigme',
     'post_status' => 'pending',
-    'post_title'  => 'Nouvelle énigme',
+    'post_title'  => TITRE_DEFAUT_ENIGME,
     'post_author' => $user_id,
   ]);
 

--- a/inc/edition/edition-organisateur.php
+++ b/inc/edition/edition-organisateur.php
@@ -69,7 +69,7 @@ function creer_organisateur_pour_utilisateur($user_id)
   $post_id = wp_insert_post([
     'post_type'   => 'organisateur',
     'post_status' => 'pending',
-    'post_title'  => 'Votre nom d’organisateur',
+    'post_title'  => TITRE_DEFAUT_ORGANISATEUR,
     'post_author' => $user_id,
   ]);
 

--- a/inc/statut-functions.php
+++ b/inc/statut-functions.php
@@ -533,8 +533,7 @@ function organisateur_est_complet(int $organisateur_id): bool
         return false;
     }
 
-    $titre = trim(get_post_field('post_title', $organisateur_id));
-    $titre_ok = $titre !== '' && strtolower($titre) !== strtolower('Votre nom d\'organisateur');
+    $titre_ok = titre_est_valide($organisateur_id);
 
     $logo = get_field('profil_public_logo_organisateur', $organisateur_id);
     $logo_ok = !empty($logo);
@@ -558,8 +557,7 @@ function chasse_est_complet(int $chasse_id): bool
         return false;
     }
 
-    $titre = trim(get_post_field('post_title', $chasse_id));
-    $titre_ok = $titre !== '' && strtolower($titre) !== strtolower('Nouvelle chasse');
+    $titre_ok = titre_est_valide($chasse_id);
 
     $desc = trim(get_field('chasse_principale_description', $chasse_id));
     $desc_ok = $desc !== '';
@@ -584,8 +582,7 @@ function enigme_est_complet(int $enigme_id): bool
         return false;
     }
 
-    $titre = trim(get_post_field('post_title', $enigme_id));
-    $titre_ok = $titre !== '' && strtolower($titre) !== strtolower('Nouvelle enigme');
+    $titre_ok = titre_est_valide($enigme_id);
 
     $images = get_field('enigme_visuel_image', $enigme_id);
     $placeholder = defined('ID_IMAGE_PLACEHOLDER_ENIGME') ? ID_IMAGE_PLACEHOLDER_ENIGME : 3925;

--- a/inc/utils/titres.php
+++ b/inc/utils/titres.php
@@ -1,0 +1,59 @@
+<?php
+defined('ABSPATH') || exit;
+
+/**
+ * ============================================================
+ * 🏷️  TITRES PAR DÉFAUT ET VALIDATION
+ * ============================================================
+ *
+ * Centralise les valeurs par défaut utilisées lors de la création
+ * automatique des posts (organisateur, chasse, énigme) et fournit
+ * une fonction utilitaire pour vérifier si un titre a été modifié.
+ */
+
+// Valeurs par défaut des titres lors de la création des CPT
+define('TITRE_DEFAUT_ORGANISATEUR', 'Votre nom d’organisateur');
+define('TITRE_DEFAUT_CHASSE', 'Nouvelle chasse');
+define('TITRE_DEFAUT_ENIGME', 'Nouvelle énigme');
+
+/**
+ * Retourne le titre par défaut associé à un type de post donné.
+ *
+ * @param string $post_type Type de post (organisateur, chasse, énigme).
+ * @return string Titre par défaut ou chaîne vide si inconnu.
+ */
+function get_titre_defaut(string $post_type): string {
+    switch ($post_type) {
+        case 'organisateur':
+            return TITRE_DEFAUT_ORGANISATEUR;
+        case 'chasse':
+            return TITRE_DEFAUT_CHASSE;
+        case 'enigme':
+            return TITRE_DEFAUT_ENIGME;
+        default:
+            return '';
+    }
+}
+
+/**
+ * Indique si le titre d'un post est considéré comme rempli.
+ *
+ * Le titre est jugé invalide s'il est vide ou identique au titre par défaut
+ * utilisé lors de la création du post.
+ *
+ * @param int $post_id ID du post à vérifier.
+ * @return bool True si le titre est différent du titre par défaut et non vide.
+ */
+function titre_est_valide(int $post_id): bool {
+    $titre = trim(get_post_field('post_title', $post_id));
+    if ($titre === '') {
+        return false;
+    }
+
+    $defaut = get_titre_defaut(get_post_type($post_id));
+    if ($defaut !== '' && strcasecmp($titre, $defaut) === 0) {
+        return false;
+    }
+
+    return true;
+}

--- a/template-parts/enigme/chasse-partial-boucle-enigmes.php
+++ b/template-parts/enigme/chasse-partial-boucle-enigmes.php
@@ -40,6 +40,7 @@ $has_enigmes = !empty($posts_visibles);
     $voir_bordure = !empty($est_orga) && utilisateur_est_organisateur_associe_a_chasse($utilisateur_id, $chasse_id);
     $classe_completion = '';
     if ($voir_bordure) {
+      verifier_ou_mettre_a_jour_cache_complet($enigme_id);
       $complet = (bool) get_field('enigme_cache_complet', $enigme_id);
       $classe_completion = $complet ? 'carte-complete' : 'carte-incomplete';
     }

--- a/template-parts/enigme/enigme-edition-main.php
+++ b/template-parts/enigme/enigme-edition-main.php
@@ -14,7 +14,7 @@ if (!$enigme_id || get_post_type($enigme_id) !== 'enigme') {
 
 $peut_modifier = utilisateur_peut_modifier_post($enigme_id);
 $titre = get_the_title($enigme_id);
-$titre_defaut = 'Nouvelle énigme';
+$titre_defaut = TITRE_DEFAUT_ENIGME;
 $isTitreParDefaut = strtolower(trim($titre)) === strtolower($titre_defaut);
 
 $visuel = get_field('enigme_visuel_image', $enigme_id); // champ "gallery" → tableau d’IDs


### PR DESCRIPTION
## Summary
- centralize default titles into `utils/titres.php`
- load new utilities earlier in `functions.php`
- use constants when creating CPTs and passing defaults to JS
- add `titre_est_valide()` to detect if a post's title differs from the default
- apply new helper in completion checks
- update template to rely on new constant
- refresh puzzle completion state before each display

## Testing
- `php -l inc/utils/titres.php` *(fails: `php` not found)*
- `php -l template-parts/enigme/chasse-partial-boucle-enigmes.php` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68592af932a48332b8bbc6a78c3038d6