### PR TITLE
Update profile creation flow

### DIFF
--- a/templates/page-creer-profil.php
+++ b/templates/page-creer-profil.php
@@ -20,7 +20,7 @@ rediriger_selon_etat_organisateur();
 // 3. Gestion de la demande en cours
 if (isset($_GET['resend'])) {
     renvoyer_email_confirmation_organisateur($current_user_id);
-    echo '<p>✉️ Un nouvel email de confirmation a été envoyé.</p>';
+    wp_redirect(add_query_arg('notice', 'profil_verification', home_url('/mon-compte/')));
     exit;
 }
 
@@ -33,5 +33,5 @@ if ($token) {
 
 // 4. Nouvelle demande
 lancer_demande_organisateur($current_user_id);
-echo '<p>✉️ Un email de vérification vous a été envoyé. Veuillez cliquer sur le lien pour confirmer votre demande.</p>';
+wp_redirect(add_query_arg('notice', 'profil_verification', home_url('/mon-compte/')));
 exit;

--- a/woocommerce/myaccount/my-account.php
+++ b/woocommerce/myaccount/my-account.php
@@ -6,6 +6,10 @@ defined( 'ABSPATH' ) || exit;
 $current_user = wp_get_current_user();
 $roles_utilisateur = $current_user->roles;
 
+if (isset($_GET['notice']) && $_GET['notice'] === 'profil_verification') {
+    echo '<div class="woocommerce-message" role="alert">✉️ Un email de vérification vous a été envoyé. Veuillez cliquer sur le lien pour confirmer votre demande.</div>';
+}
+
 if ( in_array('administrator', $roles_utilisateur) ) {
     require 'admin.php';
 } elseif ( array_intersect(['organisateur', 'organisateur_creation'], $roles_utilisateur) ) {


### PR DESCRIPTION
## Summary
- send organizer profile creation notice then redirect to `/mon-compte`
- display notice on account page when `notice=profil_verification`

## Testing
- `php -l templates/page-creer-profil.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68594a240c44833284579ac63284ac85