### PR TITLE
Fix organiser confirmation redirection

### DIFF
--- a/inc/organisateur-functions.php
+++ b/inc/organisateur-functions.php
@@ -382,3 +382,49 @@ function confirmer_demande_organisateur(int $user_id, string $token): ?int {
     return $organisateur_id;
 }
 
+// ==================================================
+// 🌐 ENDPOINT CONFIRMATION ORGANISATEUR
+// ==================================================
+/**
+ * Enregistre l'endpoint /confirmation-organisateur
+ *
+ * Permet d'accéder à l'URL https://exemple.com/confirmation-organisateur/
+ * même si aucune page WordPress n'existe.
+ */
+function register_endpoint_confirmation_organisateur() {
+    add_rewrite_rule('^confirmation-organisateur/?$', 'index.php?confirmation_organisateur=1', 'top');
+    add_rewrite_tag('%confirmation_organisateur%', '1');
+}
+add_action('init', 'register_endpoint_confirmation_organisateur');
+
+/**
+ * Traite la confirmation d'inscription organisateur et redirige.
+ *
+ * Vérifie le token, crée le CPT "organisateur" si nécessaire, connecte
+ * l'utilisateur puis redirige vers son espace organisateur.
+ */
+function traiter_confirmation_organisateur() {
+    if (get_query_var('confirmation_organisateur') !== '1') {
+        return;
+    }
+
+    $user_id = isset($_GET['user']) ? intval($_GET['user']) : 0;
+    $token   = isset($_GET['token']) ? sanitize_text_field($_GET['token']) : '';
+
+    $organisateur_id = 0;
+    if ($user_id && $token) {
+        $organisateur_id = confirmer_demande_organisateur($user_id, $token);
+    }
+
+    if ($organisateur_id) {
+        wp_set_current_user($user_id);
+        wp_set_auth_cookie($user_id);
+        $redirect = add_query_arg('confirmation', '1', get_permalink($organisateur_id));
+        wp_safe_redirect($redirect);
+    } else {
+        wp_safe_redirect(home_url('/devenir-organisateur'));
+    }
+    exit;
+}
+add_action('template_redirect', 'traiter_confirmation_organisateur');
+

--- a/inc/relations-functions.php
+++ b/inc/relations-functions.php
@@ -33,11 +33,15 @@ function get_organisateur_from_user($user_id)
 {
   global $wpdb;
 
-  // Rechercher l'ID du post organisateur lié à l'utilisateur
+  // Recherche l'ID du post organisateur actif lié à l'utilisateur
   $post_id = $wpdb->get_var($wpdb->prepare(
-    "SELECT post_id FROM $wpdb->postmeta 
-        WHERE meta_key = 'utilisateurs_associes' 
-        AND meta_value LIKE %s LIMIT 1",
+    "SELECT p.ID FROM $wpdb->posts p
+      INNER JOIN $wpdb->postmeta pm ON p.ID = pm.post_id
+      WHERE pm.meta_key = 'utilisateurs_associes'
+        AND pm.meta_value LIKE %s
+        AND p.post_type = 'organisateur'
+        AND p.post_status IN ('publish','pending','draft')
+      LIMIT 1",
     '%"' . esc_sql($user_id) . '"%'
   ));
 

--- a/single-organisateur.php
+++ b/single-organisateur.php
@@ -53,6 +53,10 @@ get_header();
             ?>
         <?php endif; ?>
 
+        <?php if (!empty($_GET['confirmation'])) : ?>
+            <p class="message-succes">Votre inscription est confirmée. Vous pouvez maintenant vous connecter.</p>
+        <?php endif; ?>
+
         <!-- Présentation -->
         <section class="presentation">
             <div class="conteneur">


### PR DESCRIPTION
## Summary
- handle organiser confirmation via custom endpoint
- redirect to CPT page with confirmation message
- improve organiser lookup to ensure the CPT really exists

## Testing
- `php -l inc/relations-functions.php` *(fails: `php` not found)*
- `php -l inc/organisateur-functions.php` *(fails: `php` not found)*
- `php -l single-organisateur.php` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68594b7eb6cc8332ab364b6692eacec4