### PR TITLE
Add highlight for empty required fields

### DIFF
--- a/assets/js/core/resume.js
+++ b/assets/js/core/resume.js
@@ -315,6 +315,8 @@ window.onChampSimpleMisAJour = function (champ, postId, valeur, cpt) {
 function mettreAJourLigneResume(ligne, champ, estRempli, type) {
   ligne.classList.toggle('champ-rempli', estRempli);
   ligne.classList.toggle('champ-vide', !estRempli);
+  const estObligatoire = ligne.closest('.resume-bloc')?.classList.contains('resume-obligatoire');
+  ligne.classList.toggle('champ-attention', estObligatoire && !estRempli);
 
   // Nettoyer anciennes icônes
   ligne.querySelectorAll(':scope > .icone-check, :scope > .icon-attente').forEach((i) => i.remove());


### PR DESCRIPTION
## Summary
- add attention indicator on empty required fields in edit panels

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68597ef908708332bf3ded21865b1d77