### PR TITLE
Fix welcome modal visibility

### DIFF
--- a/assets/css/organisateurs.css
+++ b/assets/css/organisateurs.css
@@ -153,7 +153,7 @@
 
 .modal-bienvenue {
   position: fixed;
-  z-index: 9999;
+  z-index: 10001;
   top: 0; left: 0;
   width: 100%; height: 100%;
   background: rgba(0, 0, 0, 0.65);


### PR DESCRIPTION
## Summary
- fix z-index for organiser welcome modal so it appears over editing panel

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68598199563c8332b1563fdf4acf4f59