### PR TITLE
Fix welcome modal closing

### DIFF
--- a/single-chasse.php
+++ b/single-chasse.php
@@ -185,10 +185,23 @@ if (!$modal_deja_vue) :
     </div>
     <script>
       window.addEventListener('DOMContentLoaded', () => {
-        document.querySelector('.modal-bienvenue-wrapper')?.classList.add('visible');
-      });
-      document.querySelector('.modal-close-top')?.addEventListener('click', () => {
-        document.querySelector('.modal-bienvenue-wrapper')?.remove();
+        const wrapper = document.querySelector('.modal-bienvenue-wrapper');
+        if (!wrapper) return;
+        wrapper.classList.add('visible');
+
+        const fermer = () => wrapper.remove();
+
+        wrapper.querySelectorAll('.modal-close-top').forEach(btn => {
+          btn.addEventListener('click', fermer);
+        });
+
+        wrapper.addEventListener('click', e => {
+          if (e.target === wrapper) fermer();
+        });
+
+        document.addEventListener('keydown', e => {
+          if (e.key === 'Escape') fermer();
+        });
       });
     </script>
     <style>


### PR DESCRIPTION
## Summary
- fix close logic of the chasse welcome modal
  - attach handlers only after DOM is ready
  - support multiple close buttons
  - allow closing via Escape key and outside click

## Testing
- `pre-commit` *(fails: no such command)*

------
https://chatgpt.com/codex/tasks/task_e_68598c04aadc8332a02b32c50841d6a8