### PR TITLE
Restrict add riddle card visibility

### DIFF
--- a/assets/css/cartes.css
+++ b/assets/css/cartes.css
@@ -150,7 +150,8 @@
   color: var(--color-secondary);
 }
 
-.carte-ajout-chasse .overlay-message {
+.carte-ajout-chasse .overlay-message,
+.carte-ajout-enigme .overlay-message {
   position: absolute;
   top: 0;
   left: 0;

--- a/assets/css/edition.css
+++ b/assets/css/edition.css
@@ -911,6 +911,12 @@ body.panneau-ouvert::before {
   filter: grayscale(100%);
 }
 
+.carte-ajout-enigme.disabled {
+  pointer-events: none;
+  opacity: 0.5;
+  filter: grayscale(100%);
+}
+
 /* ==================================================
    🗂️ ONGLET MODAL D'ÉDITION
    ================================================== */

--- a/assets/js/chasse-edit.js
+++ b/assets/js/chasse-edit.js
@@ -92,6 +92,9 @@ document.addEventListener('DOMContentLoaded', () => {
   if (typeof window.mettreAJourResumeInfos === 'function') {
     window.mettreAJourResumeInfos();
   }
+  if (typeof window.mettreAJourCarteAjoutEnigme === 'function') {
+    window.mettreAJourCarteAjoutEnigme();
+  }
 
   // ==============================
   // 📅 Gestion Date de fin + Durée illimitée
@@ -615,6 +618,54 @@ function initChampNbGagnants() {
 
 // À appeler :
 initChampNbGagnants();
+
+// ==============================
+// ➕ Mise à jour de la carte d'ajout d'énigme
+// ==============================
+window.mettreAJourCarteAjoutEnigme = function () {
+  const carte = document.getElementById('carte-ajout-enigme');
+  if (!carte) return;
+
+  const panel = document.querySelector('.edition-panel-chasse');
+  if (!panel) return;
+
+  const selectors = [
+    '[data-champ="post_title"]',
+    '[data-champ="chasse_principale_image"]',
+    '[data-champ="chasse_principale_description"]'
+  ];
+
+  const incomplets = selectors.filter(sel => {
+    const li = panel.querySelector('.resume-infos ' + sel);
+    return li && li.classList.contains('champ-vide');
+  });
+
+  let overlay = carte.querySelector('.overlay-message');
+
+  if (incomplets.length === 0) {
+    carte.classList.remove('disabled');
+    overlay?.remove();
+  } else {
+    carte.classList.add('disabled');
+    const texte = incomplets.map(sel => {
+      if (sel.includes('post_title')) return 'titre';
+      if (sel.includes('image')) return 'image';
+      if (sel.includes('description')) return 'description';
+      return 'champ requis';
+    }).join(', ');
+
+    if (!overlay) {
+      overlay = document.createElement('div');
+      overlay.className = 'overlay-message';
+      carte.appendChild(overlay);
+    }
+
+    overlay.innerHTML = `
+      <i class="fa-solid fa-circle-info"></i>
+      <p>Complétez d’abord : ${texte}</p>
+    `;
+  }
+};
 
 
 // ================================

--- a/assets/js/core/resume.js
+++ b/assets/js/core/resume.js
@@ -218,6 +218,9 @@ window.mettreAJourResumeInfos = function () {
   if (typeof window.mettreAJourCarteAjoutChasse === 'function') {
     window.mettreAJourCarteAjoutChasse();
   }
+  if (typeof window.mettreAJourCarteAjoutEnigme === 'function') {
+    window.mettreAJourCarteAjoutEnigme();
+  }
 };
 
 // ==============================

--- a/inc/access-functions.php
+++ b/inc/access-functions.php
@@ -406,9 +406,24 @@ function utilisateur_peut_ajouter_enigme(int $chasse_id, ?int $user_id = null): 
         return false;
     }
 
-    $statut = get_field('champs_caches_chasse_cache_statut_validation', $chasse_id);
-    if (!in_array($statut, ['creation', 'correction'], true)) {
-        error_log("❌ [ajout énigme] chasse #$chasse_id statut invalide : $statut");
+    $user  = get_user_by('id', $user_id);
+    $roles = (array) ($user->roles ?? []);
+    if (!array_intersect($roles, ['organisateur', 'organisateur_creation'])) {
+        error_log("❌ [ajout énigme] rôle utilisateur #$user_id invalide");
+        return false;
+    }
+
+    $cache = get_field('champs_caches', $chasse_id);
+    $statut_validation = $cache['chasse_cache_statut_validation'] ?? null;
+    $statut_metier     = $cache['chasse_cache_statut'] ?? null;
+
+    if ($statut_metier !== 'revision') {
+        error_log("❌ [ajout énigme] chasse #$chasse_id statut metier : $statut_metier");
+        return false;
+    }
+
+    if (!in_array($statut_validation, ['creation', 'correction'], true)) {
+        error_log("❌ [ajout énigme] chasse #$chasse_id statut validation : $statut_validation");
         return false;
     }
 

--- a/template-parts/enigme/chasse-partial-ajout-enigme.php
+++ b/template-parts/enigme/chasse-partial-ajout-enigme.php
@@ -8,18 +8,25 @@ defined('ABSPATH') || exit;
  */
 
 $has_enigmes = $args['has_enigmes'] ?? false;
-$chasse_id = $args['chasse_id'] ?? null;
+$chasse_id   = $args['chasse_id'] ?? null;
+$disabled    = $args['disabled'] ?? true;
 if (!$chasse_id || get_post_type($chasse_id) !== 'chasse') return;
 
 $ajout_url = esc_url(add_query_arg('chasse_id', $chasse_id, home_url('/creer-enigme/')));
 
 ?>
 
-<div class="carte-ajout-enigme <?php echo $has_enigmes ? 'etat-suivante' : 'etat-vide'; ?>">
+<a
+  href="<?php echo $ajout_url; ?>"
+  id="carte-ajout-enigme"
+  class="carte-ajout-enigme <?php echo $has_enigmes ? 'etat-suivante' : 'etat-vide'; ?> <?php echo $disabled ? 'disabled' : ''; ?>"
+  data-post-id="0">
   <div class="contenu-carte">
-    <a href="<?php echo $ajout_url; ?>" class="bouton-principal">
-      ➕ <?php echo $has_enigmes ? 'Ajouter une énigme' : 'Créer la première énigme'; ?>
-    </a>
+    ➕ <?php echo $has_enigmes ? 'Ajouter une énigme' : 'Créer la première énigme'; ?>
   </div>
-</div>
+  <div class="overlay-message">
+    <i class="fa-solid fa-circle-info"></i>
+    <p>Complétez d’abord : titre, image, description</p>
+  </div>
+</a>
 

--- a/template-parts/enigme/chasse-partial-boucle-enigmes.php
+++ b/template-parts/enigme/chasse-partial-boucle-enigmes.php
@@ -61,9 +61,12 @@ $has_enigmes = !empty($posts_visibles);
 
   <?php
   if (utilisateur_peut_ajouter_enigme($chasse_id, $utilisateur_id)) {
+    verifier_ou_mettre_a_jour_cache_complet($chasse_id);
+    $complete = (bool) get_field('chasse_cache_complet', $chasse_id);
     get_template_part('template-parts/enigme/chasse-partial-ajout-enigme', null, [
       'has_enigmes' => $has_enigmes,
       'chasse_id'   => $chasse_id,
+      'disabled'    => !$complete,
     ]);
   }
   ?>


### PR DESCRIPTION
## Summary
- disable the add riddle card unless hunt is complete
- tighten checks before allowing riddle creation
- support disabling add riddle card via JS
- style disabled riddle card and overlay

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68598f2295108332a8e7724619280607