### PR TITLE
Fix validation modal readability and button toggle

### DIFF
--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -127,6 +127,11 @@ button,
 .bouton-cta:hover {
     background-color: var(--color-secondary);
 }
+.bouton-cta:disabled {
+    background: var(--color-gris-3);
+    cursor: not-allowed;
+    opacity: 0.6;
+}
 @media (max-width: 768px) {
     .bouton-cta {
         padding: 8px 13px;

--- a/assets/css/organisateurs.css
+++ b/assets/css/organisateurs.css
@@ -187,6 +187,7 @@
   align-items: flex-start;
   gap: 8px;
   margin-top: 1rem;
+  color: var(--color-text-fond-clair);
 }
 .modal-confirmation-validation-chasse input[type="checkbox"] {
   transform: scale(1.2);


### PR DESCRIPTION
## Summary
- improve text contrast in validation modal
- style CTA buttons when disabled

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68599ad2b2e083328c1d3fa85b7c2cd9