### PR TITLE
Remove internal edit warning on enigme view

### DIFF
--- a/inc/enigme-functions.php
+++ b/inc/enigme-functions.php
@@ -603,14 +603,6 @@
             return;
         }
 
-        if ($etat !== 'accessible') {
-            echo '<div class="enigme-message-interne">';
-            echo '<p>🛠️ Cette énigme est en cours d’édition.</p>';
-            echo '<p class="explication-organisateur">Elle ne sera visible par les joueurs qu’une fois la chasse validée.</p>';
-            echo '</div>';
-        }
-
-
         if (!empty($statut_data['afficher_message'])) {
             echo $statut_data['message_html'];
         }


### PR DESCRIPTION
## Summary
- remove internal edit notice from enigme display

## Testing
- `npm test` *(fails: could not find package.json)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859b807c0108332931161e899b3a63d