### PR TITLE
Add incomplete indicators for chasse elements

### DIFF
--- a/assets/css/cartes.css
+++ b/assets/css/cartes.css
@@ -174,5 +174,6 @@
 }
 
 .carte-incomplete {
-  border: 2px solid var(--color-editor-error);
+  border: 2px dashed var(--color-editor-error);
+  animation: clignoteTitre 1s infinite alternate;
 }

--- a/assets/css/chasse.css
+++ b/assets/css/chasse.css
@@ -77,6 +77,13 @@
     margin-bottom: 0;
 }
 
+.chasse-section-intro.champ-vide-obligatoire {
+    border: 2px dashed var(--color-editor-error);
+    animation: clignoteTitre 1s infinite alternate;
+    padding: 0.5rem;
+    border-radius: 0.5rem;
+}
+
 
 
 /* ========== 🧾 BLOC PRÉSENTATION DE LA CHASSE ========== */

--- a/assets/css/edition.css
+++ b/assets/css/edition.css
@@ -90,7 +90,7 @@ body.edition-active .champ-organisateur.champ-vide:hover {
   cursor: pointer;
 }
 
-.champ-organisateur.champ-vide-obligatoire {
+.champ-vide-obligatoire {
   border: 2px dashed var(--color-editor-error);
   animation: clignoteTitre 1s infinite alternate;
 }

--- a/template-parts/chasse/chasse-affichage-complet.php
+++ b/template-parts/chasse/chasse-affichage-complet.php
@@ -70,10 +70,15 @@ if (current_user_can('administrator')) {
 }
 
 
+$classe_intro = 'chasse-section-intro';
+$est_complet = chasse_est_complet($chasse_id);
+if ($edition_active && !$est_complet) {
+  $classe_intro .= ' champ-vide-obligatoire';
+}
 ?>
 
 
-<section class="chasse-section-intro">
+<section class="<?= esc_attr($classe_intro); ?>">
 
   <div class="chasse-fiche-container flex-row">
     <?php

--- a/template-parts/organisateur/organisateur-header.php
+++ b/template-parts/organisateur/organisateur-header.php
@@ -31,12 +31,17 @@ if (!$email_contact || !is_email($email_contact)) {
 
 $base_url = trailingslashit(get_permalink($organisateur_id));
 $url_contact = esc_url($base_url . 'contact?email_organisateur=' . urlencode($email_contact));
+$est_complet = organisateur_est_complet($organisateur_id);
+$classes_header = 'header-organisateur';
+if ($peut_modifier && !$est_complet) {
+  $classes_header .= ' champ-organisateur champ-vide-obligatoire';
+}
 ?>
 <div class="header-organisateur-wrapper">
   <div class="ligne-morse" aria-hidden="true">
     <div class="morse-wrapper" data-morse="<?= esc_attr($titre_organisateur); ?>"></div>
   </div>
-  <header class="header-organisateur">
+  <header class="<?= esc_attr($classes_header); ?>">
     <div class="conteneur-organisateur">
 
       <!-- Colonne gauche : logo -->

--- a/template-parts/organisateur/organisateur-partial-boucle-chasses.php
+++ b/template-parts/organisateur/organisateur-partial-boucle-chasses.php
@@ -19,6 +19,7 @@ $posts = is_a($query, 'WP_Query') ? $query->posts : (array) $query;
     $voir_bordure = !empty($est_orga) && utilisateur_est_organisateur_associe_a_chasse(get_current_user_id(), $chasse_id);
     $classe_completion = '';
     if ($voir_bordure) {
+      verifier_ou_mettre_a_jour_cache_complet($chasse_id);
       $complet = (bool) get_field('chasse_cache_complet', $chasse_id);
       $classe_completion = $complet ? 'carte-complete' : 'carte-incomplete';
     }


### PR DESCRIPTION
## Summary
- create global `.champ-vide-obligatoire` style
- animate `.carte-incomplete` with dashed red border
- mark intro section as incomplete when chasse isn't ready
- refresh cache check for organiser chasse cards

## Testing
- `git status --short`
- `php -l` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859b8ada5388332bc60cdc8b327b3b1