### PR TITLE
Implement enigme deletion

### DIFF
--- a/assets/js/enigme-edit.js
+++ b/assets/js/enigme-edit.js
@@ -265,12 +265,39 @@ document.addEventListener('DOMContentLoaded', () => {
 
     DEBUG && console.log('[INIT GRATUIT] valeur brute =', raw, '| valeur interprétée =', valeur);
 
-    const estGratuit = valeur === 0;
+  const estGratuit = valeur === 0;
 
-    $checkbox.checked = estGratuit;
-    $cout.disabled = estGratuit;
+  $checkbox.checked = estGratuit;
+  $cout.disabled = estGratuit;
   })();
 
+  const boutonSupprimer = document.getElementById('bouton-supprimer-enigme');
+  if (boutonSupprimer) {
+    boutonSupprimer.addEventListener('click', () => {
+      const postId = panneauEdition?.dataset.postId;
+      if (!postId) return;
+
+      if (!confirm('Voulez-vous vraiment supprimer cette énigme ?')) return;
+
+      fetch(ajaxurl, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: new URLSearchParams({
+          action: 'supprimer_enigme',
+          post_id: postId
+        })
+      })
+        .then(r => r.json())
+        .then(res => {
+          if (res.success && res.data?.redirect) {
+            window.location.href = res.data.redirect;
+          } else {
+            alert('Échec suppression : ' + (res.data || 'inconnue'));
+          }
+        })
+        .catch(() => alert('Erreur réseau'));
+    });
+  }
 
 });
 

--- a/template-parts/enigme/enigme-edition-main.php
+++ b/template-parts/enigme/enigme-edition-main.php
@@ -530,6 +530,10 @@ $has_variantes = ($nb_variantes > 0);
       </div>
     </div>
     </div> <!-- #enigme-tab-solution -->
-    <div class="edition-panel-footer"></div>
+    <div class="edition-panel-footer">
+      <?php if (utilisateur_peut_supprimer_enigme($enigme_id)) : ?>
+        <button type="button" id="bouton-supprimer-enigme" class="bouton-texte secondaire">❌ Suppression énigme</button>
+      <?php endif; ?>
+    </div>
   </section>
 <?php endif; ?>


### PR DESCRIPTION
## Summary
- add permission check `utilisateur_peut_supprimer_enigme`
- enable AJAX endpoint for deleting an enigme and folder cleanup
- support recursive removal of enigme upload folder
- display a delete button in enigme edit panel
- allow front‑end deletion via JS

## Testing
- `php -l inc/access-functions.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859c42f1b388332b6af592eece0c3db