### PR TITLE
Fix double containers

### DIFF
--- a/single-chasse.php
+++ b/single-chasse.php
@@ -66,8 +66,7 @@ $can_validate = peut_valider_chasse($chasse_id, $user_id);
 $validation_envoyee = !empty($_GET['validation_demandee']);
 ?>
 
-<div class="ast-container">
-  <div id="primary" class="content-area">
+<div id="primary" class="content-area">
     <main id="main" class="site-main">
 
       <?php
@@ -164,8 +163,7 @@ $validation_envoyee = !empty($_GET['validation_demandee']);
       ?>
 
     </main>
-  </div>
-</div>
+    </div>
 
 <?php
 // 💬 Modale d’introduction (affichée une seule fois)

--- a/single-enigme.php
+++ b/single-enigme.php
@@ -60,8 +60,7 @@ if (is_singular('enigme')) {
 ?>
 <?php get_header(); ?>
 
-<div class="ast-container">
-  <div id="primary" class="content-area">
+<div id="primary" class="content-area">
     <main id="main" class="site-main single-enigme-main statut-<?= esc_attr($statut_enigme); ?>">
 
       <?php
@@ -108,6 +107,5 @@ if (is_singular('enigme')) {
 
     </main>
   </div>
-</div>
 
 <?php get_footer(); ?>


### PR DESCRIPTION
## Summary
- avoid double container wrappers in single templates
- keep only the theme-provided wrapper

## Testing
- `php -l single-chasse.php`
- `php -l single-enigme.php`


------
https://chatgpt.com/codex/tasks/task_e_685a24f61cb0833299747d01232172c5