### PR TITLE
Add granular edition permissions

### DIFF
--- a/template-parts/chasse/chasse-edition-main.php
+++ b/template-parts/chasse/chasse-edition-main.php
@@ -12,7 +12,7 @@ if (!$chasse_id || get_post_type($chasse_id) !== 'chasse') {
   return;
 }
 
-$peut_modifier = utilisateur_peut_modifier_post($chasse_id);
+$peut_modifier = utilisateur_peut_voir_panneau($chasse_id);
 
 $image = get_field('chasse_principale_image', $chasse_id);
 $description = get_field('chasse_principale_description', $chasse_id);

--- a/template-parts/enigme/enigme-edition-main.php
+++ b/template-parts/enigme/enigme-edition-main.php
@@ -12,7 +12,7 @@ if (!$enigme_id || get_post_type($enigme_id) !== 'enigme') {
   return;
 }
 
-$peut_modifier = utilisateur_peut_modifier_post($enigme_id);
+$peut_modifier = utilisateur_peut_voir_panneau($enigme_id);
 $titre = get_the_title($enigme_id);
 $titre_defaut = TITRE_DEFAUT_ENIGME;
 $isTitreParDefaut = strtolower(trim($titre)) === strtolower($titre_defaut);

--- a/template-parts/organisateur/organisateur-edition-main.php
+++ b/template-parts/organisateur/organisateur-edition-main.php
@@ -3,7 +3,7 @@
 defined('ABSPATH') || exit;
 
 $organisateur_id = get_organisateur_id_from_context($args ?? []);
-$peut_modifier = utilisateur_peut_modifier_post($organisateur_id);
+$peut_modifier   = utilisateur_peut_voir_panneau($organisateur_id);
 
 
 // User


### PR DESCRIPTION
## Summary
- implement `utilisateur_peut_voir_panneau` and `utilisateur_peut_editer_champs` helpers
- use new helpers in organiser, chasse and enigme edition templates

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a43bd290c8332aec955b8907d2590