### PR TITLE
Add granular edition permissions

### DIFF
--- a/inc/edition/edition-chasse.php
+++ b/inc/edition/edition-chasse.php
@@ -217,6 +217,10 @@ function modifier_champ_chasse()
     wp_send_json_error('⚠️ acces_refuse');
   }
 
+  if (!utilisateur_peut_editer_champs($post_id)) {
+    wp_send_json_error('⚠️ acces_refuse');
+  }
+
   $doit_recalculer_statut = false;
   $champ_valide = false;
   $reponse = ['champ' => $champ, 'valeur' => $valeur];

--- a/inc/edition/edition-enigme.php
+++ b/inc/edition/edition-enigme.php
@@ -226,6 +226,10 @@ function modifier_champ_enigme()
     wp_send_json_error('⚠️ acces_refuse');
   }
 
+  if (!utilisateur_peut_editer_champs($post_id)) {
+    wp_send_json_error('⚠️ acces_refuse');
+  }
+
   $champ_valide = false;
   $reponse = ['champ' => $champ, 'valeur' => $valeur];
 

--- a/inc/edition/edition-organisateur.php
+++ b/inc/edition/edition-organisateur.php
@@ -197,6 +197,10 @@ function ajax_modifier_champ_organisateur()
     wp_send_json_error('⚠️ acces_refuse');
   }
 
+  if (!utilisateur_peut_editer_champs($post_id)) {
+    wp_send_json_error('⚠️ acces_refuse');
+  }
+
   // 🗺️ Table de correspondance si champ dans un groupe ACF
   $champ_correspondances = [
     'email_contact'                     => 'profil_public_email_contact',
@@ -378,6 +382,10 @@ function modifier_titre_organisateur()
 
   $auteur = (int) get_post_field('post_author', $organisateur_id);
   if ($auteur !== $user_id) {
+    wp_send_json_error('acces_refuse');
+  }
+
+  if (!utilisateur_peut_editer_champs($organisateur_id)) {
     wp_send_json_error('acces_refuse');
   }
 

--- a/template-parts/chasse/chasse-edition-main.php
+++ b/template-parts/chasse/chasse-edition-main.php
@@ -12,7 +12,8 @@ if (!$chasse_id || get_post_type($chasse_id) !== 'chasse') {
   return;
 }
 
-$peut_modifier = utilisateur_peut_modifier_post($chasse_id);
+$peut_modifier = utilisateur_peut_voir_panneau($chasse_id);
+$peut_editer   = utilisateur_peut_editer_champs($chasse_id);
 
 $image = get_field('chasse_principale_image', $chasse_id);
 $description = get_field('chasse_principale_description', $chasse_id);
@@ -78,13 +79,15 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
 
                   <div class="champ-affichage">
                     <label for="champ-titre-chasse">Titre de la chasse</label>
-                    <button type="button" class="champ-modifier" aria-label="Modifier le titre">
-                      ✏️
-                    </button>
+                    <?php if ($peut_editer) : ?>
+                      <button type="button" class="champ-modifier" aria-label="Modifier le titre">
+                        ✏️
+                      </button>
+                    <?php endif; ?>
                   </div>
 
                   <div class="champ-edition" style="display: none;">
-                    <input type="text" class="champ-input" maxlength="70" value="<?= esc_attr($titre); ?>" id="champ-titre-chasse">
+                    <input type="text" class="champ-input" maxlength="70" value="<?= esc_attr($titre); ?>" id="champ-titre-chasse" <?= $peut_editer ? '' : 'disabled'; ?>>
                     <button type="button" class="champ-enregistrer">✓</button>
                     <button type="button" class="champ-annuler">✖</button>
                   </div>
@@ -98,12 +101,14 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
                   data-cpt="chasse"
                   data-post-id="<?= esc_attr($chasse_id); ?>">
                   Une description
-                  <button type="button"
-                    class="champ-modifier ouvrir-panneau-description"
-                    data-cpt="chasse"
-                    data-champ="chasse_principale_description"
-                    data-post-id="<?= esc_attr($chasse_id); ?>"
-                    aria-label="Modifier la description">✏️</button>
+                  <?php if ($peut_editer) : ?>
+                    <button type="button"
+                      class="champ-modifier ouvrir-panneau-description"
+                      data-cpt="chasse"
+                      data-champ="chasse_principale_description"
+                      data-post-id="<?= esc_attr($chasse_id); ?>"
+                      aria-label="Modifier la description">✏️</button>
+                  <?php endif; ?>
                 </li>
 
                 <!-- Image -->
@@ -112,12 +117,14 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
                   data-cpt="chasse"
                   data-post-id="<?= esc_attr($chasse_id); ?>">
                   Une image principale
-                  <button type="button"
-                    class="champ-modifier"
-                    data-champ="chasse_principale_image"
-                    data-cpt="chasse"
-                    data-post-id="<?= esc_attr($chasse_id); ?>"
-                    aria-label="Modifier l’image">✏️</button>
+                  <?php if ($peut_editer) : ?>
+                    <button type="button"
+                      class="champ-modifier"
+                      data-champ="chasse_principale_image"
+                      data-cpt="chasse"
+                      data-post-id="<?= esc_attr($chasse_id); ?>"
+                      aria-label="Modifier l’image">✏️</button>
+                  <?php endif; ?>
                 </li>
 
               </ul>
@@ -131,7 +138,9 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
                 <!-- Récompense -->
                 <li class="champ-chasse champ-rempli" data-champ="caracteristiques_chasse_infos_recompense_valeur" data-cpt="chasse" data-post-id="8991">
                   Récompense
-                  <button type="button" class="champ-modifier ouvrir-panneau-recompense" data-champ="caracteristiques_chasse_infos_recompense_valeur" data-cpt="chasse" data-post-id="8991" aria-label="Modifier la récompense">✏️</button>
+                  <?php if ($peut_editer) : ?>
+                    <button type="button" class="champ-modifier ouvrir-panneau-recompense" data-champ="caracteristiques_chasse_infos_recompense_valeur" data-cpt="chasse" data-post-id="8991" aria-label="Modifier la récompense">✏️</button>
+                  <?php endif; ?>
                 </li>
 
                 <!-- Liens -->
@@ -142,12 +151,14 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
 
                   <span class="champ-label">Sites et réseaux dédiés à cette chasse</span>
 
-                  <button type="button"
-                    class="champ-modifier ouvrir-panneau-liens"
-                    data-champ="chasse_principale_liens"
-                    data-cpt="chasse"
-                    data-post-id="<?= esc_attr($chasse_id); ?>"
-                    aria-label="Configurer les liens publics">✏️</button>
+                  <?php if ($peut_editer) : ?>
+                    <button type="button"
+                      class="champ-modifier ouvrir-panneau-liens"
+                      data-champ="chasse_principale_liens"
+                      data-cpt="chasse"
+                      data-post-id="<?= esc_attr($chasse_id); ?>"
+                      aria-label="Configurer les liens publics">✏️</button>
+                  <?php endif; ?>
 
                   <div class="champ-feedback"></div>
                 </li>
@@ -170,7 +181,7 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
                     id="chasse-date-debut"
                     name="chasse-date-debut"
                     value="<?= esc_attr($date_debut); ?>"
-                    class="champ-inline-date champ-date-edit" required />
+                    class="champ-inline-date champ-date-edit" <?= $peut_editer ? '' : 'disabled'; ?> required />
                   <div id="erreur-date-debut" class="message-erreur" style="display:none; color:red; font-size:0.9em; margin-top:5px;"></div>
 
                 </li>
@@ -186,7 +197,7 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
                     id="chasse-date-fin"
                     name="chasse-date-fin"
                     value="<?= esc_attr($date_fin); ?>"
-                    class="champ-inline-date champ-date-edit" />
+                    class="champ-inline-date champ-date-edit" <?= $peut_editer ? '' : 'disabled'; ?> />
                   <div id="erreur-date-fin" class="message-erreur" style="display:none; color:red; font-size:0.9em; margin-top:5px;"></div>
 
                   <div class="champ-option-illimitee">
@@ -194,7 +205,7 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
                       id="duree-illimitee"
                       name="duree-illimitee"
                       data-champ="caracteristiques.chasse_infos_duree_illimitee"
-                      <?= ($illimitee ? 'checked' : ''); ?>>
+                      <?= ($illimitee ? 'checked' : ''); ?> <?= $peut_editer ? '' : 'disabled'; ?>>
                     <label for="duree-illimitee">Durée illimitée</label>
                   </div>
 
@@ -217,13 +228,13 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
                       min="0"
                       step="1"
                       value="<?= esc_attr($cout); ?>"
-                      placeholder="0" />
+                      placeholder="0" <?= $peut_editer ? '' : 'disabled'; ?> />
 
                     <div class="champ-option-gratuit" style="margin-left: 15px;">
                       <input type="checkbox"
                         id="cout-gratuit"
                         name="cout-gratuit"
-                        <?= ((int)$cout === 0) ? 'checked' : ''; ?>>
+                        <?= ((int)$cout === 0) ? 'checked' : ''; ?> <?= $peut_editer ? '' : 'disabled'; ?>>
                       <label for="cout-gratuit">Gratuit</label>
                     </div>
                   </div>
@@ -246,13 +257,13 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
                     value="<?= esc_attr($nb_max); ?>"
                     min="1"
                     class="champ-inline-nb champ-nb-edit"
-                    <?= ($nb_max == 0 ? 'disabled' : ''); ?> />
+                    <?= ($peut_editer && $nb_max != 0) ? '' : 'disabled'; ?> />
 
                   <div class="champ-option-illimitee ">
                     <input type="checkbox"
                       id="nb-gagnants-illimite"
                       name="nb-gagnants-illimite"
-                      <?= ($nb_max == 0 ? 'checked' : ''); ?>
+                      <?= ($nb_max == 0 ? 'checked' : ''); ?> <?= $peut_editer ? '' : 'disabled'; ?>
                       data-champ="caracteristiques.chasse_infos_nb_max_gagants">
                     <label for="nb-gagnants-illimite">Illimité</label>
                   </div>

--- a/template-parts/enigme/enigme-edition-main.php
+++ b/template-parts/enigme/enigme-edition-main.php
@@ -12,7 +12,8 @@ if (!$enigme_id || get_post_type($enigme_id) !== 'enigme') {
   return;
 }
 
-$peut_modifier = utilisateur_peut_modifier_post($enigme_id);
+$peut_modifier = utilisateur_peut_voir_panneau($enigme_id);
+$peut_editer   = utilisateur_peut_editer_champs($enigme_id);
 $titre = get_the_title($enigme_id);
 $titre_defaut = TITRE_DEFAUT_ENIGME;
 $isTitreParDefaut = strtolower(trim($titre)) === strtolower($titre_defaut);
@@ -105,11 +106,13 @@ $has_variantes = ($nb_variantes > 0);
 
               <div class="champ-affichage">
                 <label for="champ-titre-enigme">Titre de l’énigme</label>
-                <button type="button"
-                  class="champ-modifier"
-                  aria-label="Modifier le titre">
-                  ✏️
-                </button>
+                <?php if ($peut_editer) : ?>
+                  <button type="button"
+                    class="champ-modifier"
+                    aria-label="Modifier le titre">
+                    ✏️
+                  </button>
+                <?php endif; ?>
               </div>
 
               <div class="champ-edition" style="display: none;">
@@ -117,7 +120,7 @@ $has_variantes = ($nb_variantes > 0);
                   class="champ-input"
                   maxlength="80"
                   value="<?= esc_attr($titre); ?>"
-                  id="champ-titre-enigme">
+                  id="champ-titre-enigme" <?= $peut_editer ? '' : 'disabled'; ?> >
                 <button type="button" class="champ-enregistrer">✓</button>
                 <button type="button" class="champ-annuler">✖</button>
               </div>
@@ -136,14 +139,16 @@ $has_variantes = ($nb_variantes > 0);
 
               Image(s)
 
-              <button
-                type="button"
-                class="champ-modifier ouvrir-panneau-images"
-                data-champ="enigme_visuel_image"
-                data-cpt="enigme"
-                data-post-id="<?= esc_attr($enigme_id); ?>">
-                ✏️
-                </button>
+              <?php if ($peut_editer) : ?>
+                <button
+                  type="button"
+                  class="champ-modifier ouvrir-panneau-images"
+                  data-champ="enigme_visuel_image"
+                  data-cpt="enigme"
+                  data-post-id="<?= esc_attr($enigme_id); ?>">
+                  ✏️
+                  </button>
+              <?php endif; ?>
 
             </li>
 
@@ -159,10 +164,12 @@ $has_variantes = ($nb_variantes > 0);
             <li class="champ-enigme champ-wysiwyg" data-champ="enigme_visuel_texte" data-cpt="enigme"
               data-post-id="<?= esc_attr($enigme_id); ?>">
               Un texte principal
-              <button type="button" class="champ-modifier ouvrir-panneau-description" data-champ="enigme_visuel_texte"
-                data-cpt="enigme" data-post-id="<?= esc_attr($enigme_id); ?>">
-                ✏️
-              </button>
+              <?php if ($peut_editer) : ?>
+                <button type="button" class="champ-modifier ouvrir-panneau-description" data-champ="enigme_visuel_texte"
+                  data-cpt="enigme" data-post-id="<?= esc_attr($enigme_id); ?>">
+                  ✏️
+                </button>
+              <?php endif; ?>
             </li>
 
             <li class="champ-enigme champ-texte" data-champ="enigme_visuel_legende" data-cpt="enigme"
@@ -170,12 +177,14 @@ $has_variantes = ($nb_variantes > 0);
 
               <div class="champ-affichage">
                 Un sous-titre
-                <button type="button" class="champ-modifier" aria-label="Modifier la légende">✏️</button>
+                <?php if ($peut_editer) : ?>
+                  <button type="button" class="champ-modifier" aria-label="Modifier la légende">✏️</button>
+                <?php endif; ?>
               </div>
 
               <div class="champ-edition" style="display: none;">
                 <input type="text" class="champ-input" maxlength="100" value="<?= esc_attr($legende); ?>"
-                  placeholder="Ajouter une légende (max 100 caractères)">
+                  placeholder="Ajouter une légende (max 100 caractères)" <?= $peut_editer ? '' : 'disabled'; ?>>
                 <button type="button" class="champ-enregistrer">✓</button>
                 <button type="button" class="champ-annuler">✖</button>
               </div>
@@ -194,9 +203,9 @@ $has_variantes = ($nb_variantes > 0);
             <div class="champ-enigme champ-mode-validation" data-champ="enigme_mode_validation" data-cpt="enigme" data-post-id="<?= esc_attr($enigme_id); ?>">
               <fieldset>
                 <legend>Validation de l’énigme</legend>
-                <label><input type="radio" name="acf[enigme_mode_validation]" value="aucune" <?= $mode_validation === 'aucune' ? 'checked' : ''; ?>> Aucune validation</label>
-                <label><input type="radio" name="acf[enigme_mode_validation]" value="manuelle" <?= $mode_validation === 'manuelle' ? 'checked' : ''; ?>> Validation manuelle</label>
-                <label><input type="radio" name="acf[enigme_mode_validation]" value="automatique" <?= $mode_validation === 'automatique' ? 'checked' : ''; ?>> Validation automatique</label>
+                <label><input type="radio" name="acf[enigme_mode_validation]" value="aucune" <?= $mode_validation === 'aucune' ? 'checked' : ''; ?> <?= $peut_editer ? '' : 'disabled'; ?>> Aucune validation</label>
+                <label><input type="radio" name="acf[enigme_mode_validation]" value="manuelle" <?= $mode_validation === 'manuelle' ? 'checked' : ''; ?> <?= $peut_editer ? '' : 'disabled'; ?>> Validation manuelle</label>
+                <label><input type="radio" name="acf[enigme_mode_validation]" value="automatique" <?= $mode_validation === 'automatique' ? 'checked' : ''; ?> <?= $peut_editer ? '' : 'disabled'; ?>> Validation automatique</label>
                 <div class="champ-explication champ-explication-validation" aria-live="polite"></div>
               </fieldset>
             </div>
@@ -227,7 +236,7 @@ $has_variantes = ($nb_variantes > 0);
                   <label style="display:inline-block; margin-right: 15px;">
                     <input type="radio" name="acf[enigme_acces_condition]"
                       value="<?= esc_attr($val); ?>"
-                      <?= $condition === $val ? 'checked' : ''; ?>>
+                      <?= $condition === $val ? 'checked' : ''; ?> <?= $peut_editer ? '' : 'disabled'; ?>>
                     <?= esc_html($label); ?>
                   </label>
                 <?php endforeach; ?>
@@ -241,7 +250,7 @@ $has_variantes = ($nb_variantes > 0);
                   id="enigme-date-deblocage"
                   name="enigme-date-deblocage"
                   value="<?= esc_attr($date_deblocage); ?>"
-                  class="champ-inline-date champ-date-edit" />
+                  class="champ-inline-date champ-date-edit" <?= $peut_editer ? '' : 'disabled'; ?> />
                 <div class="champ-feedback champ-date-feedback" style="display:none;"></div>
               </div>
 
@@ -276,7 +285,7 @@ $has_variantes = ($nb_variantes > 0);
                     ?>
                       <li>
                         <label>
-                          <input type="checkbox" value="<?= esc_attr($id); ?>" <?= $checked ? 'checked' : ''; ?>>
+                          <input type="checkbox" value="<?= esc_attr($id); ?>" <?= $checked ? 'checked' : ''; ?> <?= $peut_editer ? '' : 'disabled'; ?>>
                           <?= esc_html($titre); ?>
                         </label>
                       </li>
@@ -303,7 +312,7 @@ $has_variantes = ($nb_variantes > 0);
                         <i class="fa-solid fa-circle-question" aria-hidden="true"></i>
                       </button>
                     </label>
-                    <input type="number" class="champ-input champ-cout" min="0" step="1" value="<?= esc_attr($cout); ?>" placeholder="0" />
+                    <input type="number" class="champ-input champ-cout" min="0" step="1" value="<?= esc_attr($cout); ?>" placeholder="0" <?= $peut_editer ? '' : 'disabled'; ?> />
                   </div>
 
                   <!-- Option gratuit -->
@@ -313,7 +322,7 @@ $has_variantes = ($nb_variantes > 0);
                     $is_gratuit = $cout_normalise === '' || $cout_normalise === '0' || (int)$cout === 0;
                     ?>
                     <input type="checkbox" id="cout-gratuit-enigme" name="cout-gratuit-enigme"
-                      <?= $is_gratuit ? 'checked' : ''; ?>>
+                      <?= $is_gratuit ? 'checked' : ''; ?> <?= $peut_editer ? '' : 'disabled'; ?> >
 
                     <label for="cout-gratuit-enigme">Gratuit</label>
                   </div>
@@ -321,7 +330,7 @@ $has_variantes = ($nb_variantes > 0);
                   <!-- Nombre max de tentatives -->
                   <div class="champ-enigme champ-nb-tentatives <?= empty($max) ? 'champ-vide' : 'champ-rempli'; ?>" data-champ="enigme_tentative.enigme_tentative_max" data-cpt="enigme" data-post-id="<?= esc_attr($enigme_id); ?>">
                     <label for="enigme-nb-tentatives">Nombre max de tentatives/jour</label>
-                    <input type="number" id="enigme-nb-tentatives" class="champ-input" min="1" step="1" value="<?= esc_attr($max); ?>" placeholder="5" />
+                    <input type="number" id="enigme-nb-tentatives" class="champ-input" min="1" step="1" value="<?= esc_attr($max); ?>" placeholder="5" <?= $peut_editer ? '' : 'disabled'; ?> />
                     <p class="message-tentatives txt-small" style="margin-top: 4px;"></p>
                     <div class="champ-feedback"></div>
                   </div>
@@ -346,7 +355,7 @@ $has_variantes = ($nb_variantes > 0);
                   name="champ-bonne-reponse"
                   class="champ-input champ-texte-edit"
                   value="<?= esc_attr($reponse); ?>"
-                  placeholder="Ex : soleil" />
+                  placeholder="Ex : soleil" <?= $peut_editer ? '' : 'disabled'; ?> />
 
                 <div class="champ-feedback"></div>
               </div>
@@ -355,7 +364,7 @@ $has_variantes = ($nb_variantes > 0);
                 data-champ="enigme_reponse_casse"
                 data-cpt="enigme"
                 data-post-id="<?= esc_attr($enigme_id); ?>">
-                <label><input type="checkbox" <?= $casse ? 'checked' : ''; ?>> Respecter la casse</label>
+                <label><input type="checkbox" <?= $casse ? 'checked' : ''; ?> <?= $peut_editer ? '' : 'disabled'; ?>> Respecter la casse</label>
                 <div class="champ-feedback"></div>
               </div>
 
@@ -369,13 +378,15 @@ $has_variantes = ($nb_variantes > 0);
                   ? ($nb_variantes === 1 ? '1 variante ✏️' : $nb_variantes . ' variantes ✏️')
                   : '➕ Créer des variantes';
                 ?>
-                <button type="button"
-                  class="champ-modifier ouvrir-panneau-variantes"
-                  aria-label="<?= $has_variantes ? 'Éditer les variantes' : 'Créer des variantes'; ?>"
-                  data-cpt="enigme"
-                  data-post-id="<?= esc_attr($enigme_id); ?>">
-                  <?= esc_html($label); ?>
-                </button>
+                <?php if ($peut_editer) : ?>
+                  <button type="button"
+                    class="champ-modifier ouvrir-panneau-variantes"
+                    aria-label="<?= $has_variantes ? 'Éditer les variantes' : 'Créer des variantes'; ?>"
+                    data-cpt="enigme"
+                    data-post-id="<?= esc_attr($enigme_id); ?>">
+                    <?= esc_html($label); ?>
+                  </button>
+                <?php endif; ?>
               </div>
 
             </fieldset>

--- a/template-parts/organisateur/organisateur-edition-main.php
+++ b/template-parts/organisateur/organisateur-edition-main.php
@@ -3,7 +3,8 @@
 defined('ABSPATH') || exit;
 
 $organisateur_id = get_organisateur_id_from_context($args ?? []);
-$peut_modifier = utilisateur_peut_modifier_post($organisateur_id);
+$peut_modifier   = utilisateur_peut_voir_panneau($organisateur_id);
+$peut_editer     = utilisateur_peut_editer_champs($organisateur_id);
 
 
 // User
@@ -100,7 +101,7 @@ $classe_vide_coordonnees = ($iban_vide || $bic_vide) ? 'champ-vide' : '';
 
               <li class="champ-organisateur champ-logo ligne-logo <?= !empty($logo) ? 'champ-rempli' : 'champ-vide'; ?>" data-champ="profil_public_logo_organisateur">
                 Un logo
-                <?php if ($peut_modifier) : ?>
+                <?php if ($peut_editer) : ?>
                   <button type="button"
                     class="champ-modifier"
                     aria-label="Modifier le logo"
@@ -117,7 +118,7 @@ $classe_vide_coordonnees = ($iban_vide || $bic_vide) ? 'champ-vide' : '';
               <?php $class_description = empty($description) ? 'champ-vide' : 'champ-rempli'; ?>
               <li class="champ-organisateur champ-description ligne-description <?= $class_description; ?>" data-champ="description_longue">
                 Une présentation
-                <?php if ($peut_modifier) : ?>
+                <?php if ($peut_editer) : ?>
                   <button type="button"
                     class="champ-modifier ouvrir-panneau-description"
                     aria-label="Modifier la description longue">
@@ -136,7 +137,7 @@ $classe_vide_coordonnees = ($iban_vide || $bic_vide) ? 'champ-vide' : '';
 
               <li class="ligne-liens <?= ($nb_liens > 0) ? 'champ-rempli' : ''; ?>" data-champ="liens_publics">
                 des liens externes (réseau social ou site)
-                <?php if ($peut_modifier) : ?>
+                <?php if ($peut_editer) : ?>
                   <button type="button"
                     class="champ-modifier ouvrir-panneau-liens"
                     aria-label="Configurer les liens publics">
@@ -151,7 +152,7 @@ $classe_vide_coordonnees = ($iban_vide || $bic_vide) ? 'champ-vide' : '';
                   onclick="alert('Ces informations sont nécessaires uniquement pour vous verser les gains issus de la conversion de vos points en euros. Nous ne prélevons jamais d’argent.');">
                   <i class="fa-solid fa-circle-question" aria-hidden="true"></i>
                 </button>
-                <?php if ($peut_modifier) : ?>
+                <?php if ($peut_editer) : ?>
                   <button type="button"
                     id="ouvrir-coordonnees"
                     class="champ-modifier"
@@ -182,7 +183,7 @@ $classe_vide_coordonnees = ($iban_vide || $bic_vide) ? 'champ-vide' : '';
                       onclick="alert('Quand aucune adresse n est renseignée, votre email utilisateur est utilisé par défaut.');">
                       <i class="fa-solid fa-circle-question" aria-hidden="true"></i>
                     </button>
-                    <?php if ($peut_modifier) : ?>
+                    <?php if ($peut_editer) : ?>
                       <button type="button"
                         class="champ-modifier"
                         aria-label="Modifier l’adresse email de contact">
@@ -230,7 +231,7 @@ $classe_vide_coordonnees = ($iban_vide || $bic_vide) ? 'champ-vide' : '';
     <div class="edition-panel-footer"></div>
   </section>
 <?php endif; ?>
-<?php if ($peut_modifier) : ?>
+<?php if ($peut_editer) : ?>
   <?php get_template_part('template-parts/organisateur/panneaux/organisateur-edition-description', null, [
     'organisateur_id' => $organisateur_id
   ]); ?>


### PR DESCRIPTION
## Summary
- enforce `utilisateur_peut_editer_champs` in AJAX handlers
- hide/disable edition controls in organiser, chasse and enigme panels when conditions fail

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a43bd290c8332aec955b8907d2590