### PR TITLE
Fix visibility checks in loops

### DIFF
--- a/template-parts/organisateur/organisateur-partial-boucle-chasses.php
+++ b/template-parts/organisateur/organisateur-partial-boucle-chasses.php
@@ -8,6 +8,44 @@ if (!$organisateur_id || get_post_type($organisateur_id) !== 'organisateur') {
 
 $query = get_chasses_de_organisateur($organisateur_id);
 $posts = is_a($query, 'WP_Query') ? $query->posts : (array) $query;
+
+if (!function_exists('chasse_est_visible_pour_utilisateur')) {
+  /**
+   * Vérifie si une chasse doit être affichée pour l'utilisateur courant.
+   */
+  function chasse_est_visible_pour_utilisateur(int $chasse_id, int $user_id): bool
+  {
+    $status = get_post_status($chasse_id);
+    if (!in_array($status, ['pending', 'publish'], true)) {
+      return false;
+    }
+
+    $cache      = get_field('champs_caches', $chasse_id) ?: [];
+    $validation = $cache['chasse_cache_statut_validation'] ?? '';
+    if ($validation === 'banni') {
+      return false;
+    }
+
+    if ($status === 'pending') {
+      $roles = wp_get_current_user()->roles;
+      if (!array_intersect($roles, ['organisateur', 'organisateur_creation'])) {
+        return false;
+      }
+
+      if (!utilisateur_est_organisateur_associe_a_chasse($user_id, $chasse_id)) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+}
+
+// 🔒 Filtrer les chasses visibles selon leur statut et l'utilisateur courant
+$user_id = get_current_user_id();
+$posts   = array_values(array_filter($posts, function ($post) use ($user_id) {
+  return chasse_est_visible_pour_utilisateur($post->ID, $user_id);
+}));
 ?>
 
 <div class="grille-liste">


### PR DESCRIPTION
## Summary
- ensure enigma loop is displayed only when hunt is visible to user
- filter organiser chasses using same visibility rules

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685a6566e43c8332a3e7c25c39fb6ade