### PR TITLE
Allow organisers to view pending enigmas

### DIFF
--- a/inc/access-functions.php
+++ b/inc/access-functions.php
@@ -366,12 +366,13 @@ function utilisateur_peut_voir_enigme(int $enigme_id, ?int $user_id = null): boo
         return false;
     }
 
-    // ✅ Exception organisateur : accès si chasse en création ou correction
+    // ✅ Exception organisateur : accès si chasse en création, correction
+    //    ou en attente de validation
     $champs_caches = get_field('champs_caches', $chasse_id);
     $statut_validation = $champs_caches['chasse_cache_statut_validation'] ?? null;
     error_log("🧪 [voir énigme] chasse #$chasse_id → statut_validation = $statut_validation");
 
-    if (in_array($statut_validation, ['creation', 'correction'], true)) {
+    if (in_array($statut_validation, ['creation', 'correction', 'en_attente'], true)) {
         $autorise = in_array($post_status, ['publish', 'pending', 'draft'], true);
         error_log("🟡 [voir énigme] organisateur → chasse = $statut_validation → accès " . ($autorise ? 'OK' : 'REFUSÉ'));
         return $autorise;


### PR DESCRIPTION
## Summary
- let organisers view enigmas when hunt status is `en_attente`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685a6f3c08548332879fa1790e531ee3