### PR TITLE
Add global hunt visibility helper

### DIFF
--- a/inc/access-functions.php
+++ b/inc/access-functions.php
@@ -1056,6 +1056,41 @@ get_cta_enigme() (à déplacer ici si elle migre du fichier visuel)
 tout helper type est_cliquable, affiche_indice, etc. */
 
 /**
+ * Détermine si une chasse doit être visible pour un utilisateur.
+ *
+ * @param int $chasse_id ID de la chasse.
+ * @param int $user_id   ID de l'utilisateur.
+ * @return bool          True si visible, false sinon.
+ */
+function chasse_est_visible_pour_utilisateur(int $chasse_id, int $user_id): bool
+{
+    $status = get_post_status($chasse_id);
+    if (!in_array($status, ['pending', 'publish'], true)) {
+        return false;
+    }
+
+    $cache      = get_field('champs_caches', $chasse_id) ?: [];
+    $validation = $cache['chasse_cache_statut_validation'] ?? '';
+    if ($validation === 'banni') {
+        return false;
+    }
+
+    if ($status === 'pending') {
+        $user  = get_userdata($user_id);
+        $roles = $user ? (array) $user->roles : [];
+        if (!array_intersect($roles, ['organisateur', 'organisateur_creation'])) {
+            return false;
+        }
+
+        if (!utilisateur_est_organisateur_associe_a_chasse($user_id, $chasse_id)) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+/**
  * Autorise la consultation des énigmes non publiées pour les organisateurs
  * associés.
  *

--- a/template-parts/enigme/chasse-partial-boucle-enigmes.php
+++ b/template-parts/enigme/chasse-partial-boucle-enigmes.php
@@ -4,39 +4,8 @@ defined('ABSPATH') || exit;
 $chasse_id = $args['chasse_id'] ?? null;
 if (!$chasse_id || get_post_type($chasse_id) !== 'chasse') return;
 
+
 $utilisateur_id = get_current_user_id();
-
-if (!function_exists('chasse_est_visible_pour_utilisateur')) {
-  /**
-   * Détermine si la liste des énigmes d'une chasse doit être affichée pour un utilisateur.
-   */
-  function chasse_est_visible_pour_utilisateur(int $chasse_id, int $user_id): bool
-  {
-    $status = get_post_status($chasse_id);
-    if (!in_array($status, ['pending', 'publish'], true)) {
-      return false;
-    }
-
-    $cache       = get_field('champs_caches', $chasse_id) ?: [];
-    $validation  = $cache['chasse_cache_statut_validation'] ?? '';
-    if ($validation === 'banni') {
-      return false;
-    }
-
-    if ($status === 'pending') {
-      $roles = wp_get_current_user()->roles;
-      if (!array_intersect($roles, ['organisateur', 'organisateur_creation'])) {
-        return false;
-      }
-
-      if (!utilisateur_est_organisateur_associe_a_chasse($user_id, $chasse_id)) {
-        return false;
-      }
-    }
-
-    return true;
-  }
-}
 
 if (!chasse_est_visible_pour_utilisateur($chasse_id, $utilisateur_id)) {
   return;

--- a/template-parts/organisateur/organisateur-partial-boucle-chasses.php
+++ b/template-parts/organisateur/organisateur-partial-boucle-chasses.php
@@ -9,38 +9,6 @@ if (!$organisateur_id || get_post_type($organisateur_id) !== 'organisateur') {
 $query = get_chasses_de_organisateur($organisateur_id);
 $posts = is_a($query, 'WP_Query') ? $query->posts : (array) $query;
 
-if (!function_exists('chasse_est_visible_pour_utilisateur')) {
-  /**
-   * Vérifie si une chasse doit être affichée pour l'utilisateur courant.
-   */
-  function chasse_est_visible_pour_utilisateur(int $chasse_id, int $user_id): bool
-  {
-    $status = get_post_status($chasse_id);
-    if (!in_array($status, ['pending', 'publish'], true)) {
-      return false;
-    }
-
-    $cache      = get_field('champs_caches', $chasse_id) ?: [];
-    $validation = $cache['chasse_cache_statut_validation'] ?? '';
-    if ($validation === 'banni') {
-      return false;
-    }
-
-    if ($status === 'pending') {
-      $roles = wp_get_current_user()->roles;
-      if (!array_intersect($roles, ['organisateur', 'organisateur_creation'])) {
-        return false;
-      }
-
-      if (!utilisateur_est_organisateur_associe_a_chasse($user_id, $chasse_id)) {
-        return false;
-      }
-    }
-
-    return true;
-  }
-}
-
 // 🔒 Filtrer les chasses visibles selon leur statut et l'utilisateur courant
 $user_id = get_current_user_id();
 $posts   = array_values(array_filter($posts, function ($post) use ($user_id) {


### PR DESCRIPTION
## Summary
- add `chasse_est_visible_pour_utilisateur` helper to `inc/access-functions.php`
- remove duplicate function implementations from templates
- use new helper in hunt and organizer views

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a6f4483d48332bd2a18fbe089cafc