### PR TITLE
Lock post titles and set validation status

### DIFF
--- a/inc/access-functions.php
+++ b/inc/access-functions.php
@@ -700,6 +700,16 @@ function champ_est_editable($champ, $post_id, $user_id = null)
         return $status !== 'publish';
     }
 
+    // 🔒 Le nom d'organisateur est verrouillé pour les rôles non administrateurs
+    if ($post_type === 'organisateur' && $champ === 'post_title') {
+        return current_user_can('manage_options');
+    }
+
+    // 🔒 Le titre d'une énigme suit les mêmes restrictions que dans l'admin
+    if ($post_type === 'enigme' && $champ === 'post_title') {
+        return current_user_can('manage_options');
+    }
+
     // ⚠️ Autres règles spécifiques à définir manuellement ensuite
     // Exemple :
     // if ($champ === 'caracteristiques.chasse_infos_date_debut') {

--- a/template-parts/enigme/enigme-edition-main.php
+++ b/template-parts/enigme/enigme-edition-main.php
@@ -14,6 +14,7 @@ if (!$enigme_id || get_post_type($enigme_id) !== 'enigme') {
 
 $peut_modifier = utilisateur_peut_voir_panneau($enigme_id);
 $peut_editer   = utilisateur_peut_editer_champs($enigme_id);
+$peut_editer_titre = champ_est_editable('post_title', $enigme_id);
 
 $titre = get_the_title($enigme_id);
 $titre_defaut = TITRE_DEFAUT_ENIGME;
@@ -100,14 +101,14 @@ $has_variantes = ($nb_variantes > 0);
 
           <h3>Champs obligatoires</h3>
           <ul class="resume-infos">
-            <li class="champ-enigme champ-titre <?= ($isTitreParDefaut ? 'champ-vide' : 'champ-rempli'); ?>"
+            <li class="champ-enigme champ-titre <?= ($isTitreParDefaut ? 'champ-vide' : 'champ-rempli'); ?><?= $peut_editer_titre ? '' : ' champ-desactive'; ?>"
               data-champ="post_title"
               data-cpt="enigme"
               data-post-id="<?= esc_attr($enigme_id); ?>">
 
               <div class="champ-affichage">
                 <label for="champ-titre-enigme">Titre de l’énigme</label>
-                <?php if ($peut_editer) : ?>
+                <?php if ($peut_editer_titre) : ?>
                   <button type="button"
                     class="champ-modifier"
                     aria-label="Modifier le titre">
@@ -121,7 +122,7 @@ $has_variantes = ($nb_variantes > 0);
                   class="champ-input"
                   maxlength="80"
                   value="<?= esc_attr($titre); ?>"
-                  id="champ-titre-enigme" <?= $peut_editer ? '' : 'disabled'; ?> >
+                  id="champ-titre-enigme" <?= $peut_editer_titre ? '' : 'disabled'; ?> >
                 <button type="button" class="champ-enregistrer">✓</button>
                 <button type="button" class="champ-annuler">✖</button>
               </div>

--- a/template-parts/organisateur/organisateur-edition-main.php
+++ b/template-parts/organisateur/organisateur-edition-main.php
@@ -27,6 +27,8 @@ $coordonnees  = get_field('coordonnees_bancaires', $organisateur_id);
 $liens_actifs = organisateur_get_liens_actifs($organisateur_id);
 $nb_liens = count($liens_actifs);
 
+$peut_editer_titre = champ_est_editable('post_title', $organisateur_id);
+
 $is_complete = (
   !empty($titre) &&
   !empty($logo) &&
@@ -72,14 +74,14 @@ $classe_vide_coordonnees = ($iban_vide || $bic_vide) ? 'champ-vide' : '';
           <div class="resume-bloc resume-obligatoire deux-col-bloc">
             <h3>Champs obligatoires</h3>
             <ul class="resume-infos">
-              <li class="champ-organisateur champ-titre ligne-titre <?= empty($titre) ? 'champ-vide' : 'champ-rempli'; ?><?= $peut_editer ? '' : ' champ-desactive'; ?>"
+              <li class="champ-organisateur champ-titre ligne-titre <?= empty($titre) ? 'champ-vide' : 'champ-rempli'; ?><?= $peut_editer_titre ? '' : ' champ-desactive'; ?>"
                 data-champ="post_title"
                 data-cpt="organisateur"
                 data-post-id="<?= esc_attr($organisateur_id); ?>">
 
                 <div class="champ-affichage">
                   <label for="champ-titre-organisateur">Nom d’organisateur</label>
-                  <?php if ($peut_editer) : ?>
+                  <?php if ($peut_editer_titre) : ?>
                     <button type="button"
                       class="champ-modifier"
                       aria-label="Modifier le nom d’organisateur">
@@ -93,7 +95,7 @@ $classe_vide_coordonnees = ($iban_vide || $bic_vide) ? 'champ-vide' : '';
                     class="champ-input"
                     maxlength="50"
                     value="<?= esc_attr($titre); ?>"
-                    id="champ-titre-organisateur" <?= $peut_editer ? '' : 'disabled'; ?> >
+                    id="champ-titre-organisateur" <?= $peut_editer_titre ? '' : 'disabled'; ?> >
                   <button type="button" class="champ-enregistrer">✓</button>
                   <button type="button" class="champ-annuler">✖</button>
                 </div>

--- a/templates/page-traitement-validation-chasse.php
+++ b/templates/page-traitement-validation-chasse.php
@@ -34,5 +34,13 @@ if (!peut_valider_chasse($chasse_id, $user_id)) {
 
 forcer_statut_apres_acf($chasse_id, 'en_attente');
 
+// Met à jour le statut métier pour refléter l'attente de validation
+mettre_a_jour_sous_champ_group(
+    $chasse_id,
+    'champs_caches',
+    'chasse_cache_statut',
+    'en_attente'
+);
+
 wp_redirect(add_query_arg('validation_demandee', '1', get_permalink($chasse_id)));
 exit;


### PR DESCRIPTION
## Summary
- set `chasse_cache_statut` to `en_attente` once validation is requested
- restrict organiser and enigma titles with `champ_est_editable`
- hide edit controls when titles are locked

## Testing
- `php` lint *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a7afe7fcc8332b7caf5104b53a0bb