### PR TITLE
Update WP media frame post id

### DIFF
--- a/assets/js/core/image-utils.js
+++ b/assets/js/core/image-utils.js
@@ -20,6 +20,8 @@ function initChampImage(bloc) {
       return;
     }
 
+    wp.media.view.settings.post.id = postId;
+
     const frame = wp.media({
       title: 'Choisir une image',
       multiple: false,


### PR DESCRIPTION
## Summary
- ensure image modal uses the current post's ID before initializing the media frame

## Testing
- `npm test` *(fails: could not find `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_685a8b47b7748332b6e9fbe6b3e12337