### PR TITLE
Introduce role constants

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -55,6 +55,8 @@ add_action('wp_enqueue_scripts', function () {
 
 $inc_path = get_stylesheet_directory() . '/inc/';
 
+require_once $inc_path . 'constants.php';
+
 require_once $inc_path . 'shortcodes-init.php';
 require_once $inc_path . 'enigme-functions.php';
 require_once $inc_path . 'user-functions.php';

--- a/inc/access-functions.php
+++ b/inc/access-functions.php
@@ -232,7 +232,7 @@ function utilisateur_peut_creer_post($post_type, $chasse_id = null)
                 return false; // ❌ Refus si l'utilisateur n'a pas de CPT "organisateur"
             }
 
-            if (in_array('organisateur', $user_roles, true)) {
+            if (in_array(ROLE_ORGANISATEUR, $user_roles, true)) {
                 return true; // ✅ Un organisateur peut créer plusieurs chasses
             }
 
@@ -412,7 +412,7 @@ function utilisateur_peut_ajouter_enigme(int $chasse_id, ?int $user_id = null): 
 
     $user  = get_user_by('id', $user_id);
     $roles = (array) ($user->roles ?? []);
-    if (!array_intersect($roles, ['organisateur', 'organisateur_creation'])) {
+    if (!array_intersect($roles, [ROLE_ORGANISATEUR, ROLE_ORGANISATEUR_CREATION])) {
         error_log("❌ [ajout énigme] rôle utilisateur #$user_id invalide");
         return false;
     }
@@ -502,7 +502,7 @@ function utilisateur_peut_supprimer_enigme(int $enigme_id, ?int $user_id = null)
 
     $user  = get_user_by('id', $user_id);
     $roles = (array) ($user->roles ?? []);
-    if (!array_intersect($roles, ['organisateur', 'organisateur_creation'])) {
+    if (!array_intersect($roles, [ROLE_ORGANISATEUR, ROLE_ORGANISATEUR_CREATION])) {
         return false;
     }
 
@@ -554,12 +554,12 @@ function utilisateur_peut_ajouter_chasse(int $organisateur_id): bool
     }
 
     // Organisateur : aucune limite
-    if (in_array('organisateur', $roles, true)) {
+    if (in_array(ROLE_ORGANISATEUR, $roles, true)) {
         return true;
     }
 
     // Organisateur en cours de création : uniquement si aucune chasse existante
-    if (in_array('organisateur_creation', $roles, true)) {
+    if (in_array(ROLE_ORGANISATEUR_CREATION, $roles, true)) {
         return !organisateur_a_des_chasses($organisateur_id);
     }
 
@@ -584,7 +584,7 @@ function utilisateur_peut_voir_panneau(int $post_id): bool
     $user  = wp_get_current_user();
     $roles = (array) $user->roles;
 
-    if (!array_intersect($roles, ['organisateur', 'organisateur_creation'])) {
+    if (!array_intersect($roles, [ROLE_ORGANISATEUR, ROLE_ORGANISATEUR_CREATION])) {
         return false;
     }
 
@@ -637,7 +637,7 @@ function utilisateur_peut_editer_champs(int $post_id): bool
 
     switch ($type) {
         case 'organisateur':
-            return in_array('organisateur_creation', $roles, true) && $status === 'pending';
+            return in_array(ROLE_ORGANISATEUR_CREATION, $roles, true) && $status === 'pending';
 
         case 'chasse':
             $cache = get_field('champs_caches', $post_id);
@@ -708,7 +708,7 @@ function champ_est_editable($champ, $post_id, $user_id = null)
         }
 
         // Rôle organisateur_creation : titre éditable si l'organisateur est en cours de création
-        if (in_array('organisateur_creation', $roles, true) && $status === 'pending') {
+        if (in_array(ROLE_ORGANISATEUR_CREATION, $roles, true) && $status === 'pending') {
             $chasses_query = get_chasses_de_organisateur($post_id);
             $nb_chasses    = is_a($chasses_query, 'WP_Query') ? $chasses_query->post_count : 0;
 
@@ -790,7 +790,7 @@ add_action('admin_init', function () {
     }
 
     $user = wp_get_current_user();
-    $roles_bloques = ['organisateur', 'organisateur_creation'];
+    $roles_bloques = [ROLE_ORGANISATEUR, ROLE_ORGANISATEUR_CREATION];
 
     // Autoriser AJAX, REST et média
     if (defined('DOING_AJAX') && DOING_AJAX) return;
@@ -1114,7 +1114,7 @@ function chasse_est_visible_pour_utilisateur(int $chasse_id, int $user_id): bool
 
         return $validation !== 'banni'
             && $assoc
-            && array_intersect($roles, ['organisateur', 'organisateur_creation']);
+            && array_intersect($roles, [ROLE_ORGANISATEUR, ROLE_ORGANISATEUR_CREATION]);
     }
 
     return $validation !== 'banni';
@@ -1137,7 +1137,7 @@ add_action('pre_get_posts', function ($query) {
 
     if ($query->is_singular('enigme') && is_user_logged_in()) {
         $roles = (array) wp_get_current_user()->roles;
-        if (array_intersect($roles, ['organisateur', 'organisateur_creation'])) {
+        if (array_intersect($roles, [ROLE_ORGANISATEUR, ROLE_ORGANISATEUR_CREATION])) {
             $query->set('post_status', ['publish', 'pending', 'draft']);
         }
     }

--- a/inc/admin-functions.php
+++ b/inc/admin-functions.php
@@ -189,7 +189,7 @@ function gerer_organisateur() {
         $user_id = get_post_field('post_author', $post_id);
         if ($user_id) {
             $user = new WP_User($user_id);
-            $user->set_role('organisateur'); // Assurez-vous que ce rôle existe
+            $user->set_role(ROLE_ORGANISATEUR); // Assurez-vous que ce rôle existe
         }
 
         // Envoi d'un email de confirmation
@@ -834,7 +834,7 @@ function supprimer_metas_organisateur() {
 
     // Récupération des utilisateurs ayant un rôle d'organisateur
     $organisateurs = get_users([
-        'role' => 'organisateur',
+        'role' => ROLE_ORGANISATEUR,
         'fields' => 'ID'
     ]);
 
@@ -1307,7 +1307,7 @@ function recuperer_organisateurs_en_creation() {
         return [];
     }
 
-    $users   = get_users(['role' => 'organisateur_creation']);
+    $users   = get_users(['role' => ROLE_ORGANISATEUR_CREATION]);
     $entries = [];
 
     foreach ($users as $user) {

--- a/inc/chasse-functions.php
+++ b/inc/chasse-functions.php
@@ -298,7 +298,7 @@ function peut_valider_chasse(int $chasse_id, int $user_id): bool
     }
 
     $roles = (array) $user->roles;
-    if (!array_intersect($roles, ['organisateur', 'organisateur_creation'])) {
+    if (!array_intersect($roles, [ROLE_ORGANISATEUR, ROLE_ORGANISATEUR_CREATION])) {
         return false;
     }
 

--- a/inc/constants.php
+++ b/inc/constants.php
@@ -1,0 +1,5 @@
+<?php
+defined( 'ABSPATH' ) || exit;
+
+const ROLE_ORGANISATEUR = 'organisateur';
+const ROLE_ORGANISATEUR_CREATION = 'organisateur_creation';

--- a/inc/edition/edition-chasse.php
+++ b/inc/edition/edition-chasse.php
@@ -116,8 +116,8 @@ function creer_chasse_et_rediriger_si_appel()
   error_log("✅ Organisateur trouvé : {$organisateur_id}");
 
   // 🔒 Vérification des droits de création
-  if (!current_user_can('administrator') && !current_user_can('organisateur')) {
-    if (in_array('organisateur_creation', $roles, true)) {
+  if (!current_user_can('administrator') && !current_user_can(ROLE_ORGANISATEUR)) {
+    if (in_array(ROLE_ORGANISATEUR_CREATION, $roles, true)) {
       if (organisateur_a_des_chasses($organisateur_id)) {
         wp_die('Limite atteinte');
       }

--- a/inc/edition/edition-core.php
+++ b/inc/edition/edition-core.php
@@ -155,7 +155,7 @@ function masquer_widgets_footer($params)
     $widgets_a_masquer[] = 'nav_menu-5';
   }
 
-  if (!in_array('organisateur', $roles)) {
+  if (!in_array(ROLE_ORGANISATEUR, $roles)) {
     $widgets_a_masquer[] = 'nav_menu-3';
   }
 
@@ -414,7 +414,7 @@ function injection_classe_edition_active(array $classes): array
   if (
     $post->post_type === 'organisateur' &&
     (int) get_post_field('post_author', $post->ID) === $user_id &&
-    in_array('organisateur_creation', $roles, true) &&
+    in_array(ROLE_ORGANISATEUR_CREATION, $roles, true) &&
     !get_field('organisateur_cache_complet', $post->ID)
   ) {
     verifier_ou_mettre_a_jour_cache_complet($post->ID);
@@ -430,7 +430,7 @@ function injection_classe_edition_active(array $classes): array
   // === CHASSE ===
   if (
     $post->post_type === 'chasse' &&
-    in_array('organisateur_creation', $roles, true)
+    in_array(ROLE_ORGANISATEUR_CREATION, $roles, true)
   ) {
     $organisateur_id = get_organisateur_from_chasse($post->ID);
     $associes = get_field('utilisateurs_associes', $organisateur_id, false);

--- a/inc/organisateur-functions.php
+++ b/inc/organisateur-functions.php
@@ -126,7 +126,7 @@ add_action('wp_enqueue_scripts', 'charger_script_conversion');
 function verifier_acces_conversion($user_id) {
     // 1️⃣ Vérification du rôle (bloquant immédiat)
     $user = get_userdata($user_id);
-    if (!$user || !in_array('organisateur', $user->roles)) {
+    if (!$user || !in_array(ROLE_ORGANISATEUR, $user->roles)) {
         return "Inscription en cours";
     }
 
@@ -376,7 +376,7 @@ function confirmer_demande_organisateur(int $user_id, string $token): ?int {
     $organisateur_id = creer_organisateur_pour_utilisateur($user_id);
     if ($organisateur_id) {
         $user = new WP_User($user_id);
-        $user->add_role('organisateur_creation');
+        $user->add_role(ROLE_ORGANISATEUR_CREATION);
     }
     return $organisateur_id;
 }

--- a/inc/relations-functions.php
+++ b/inc/relations-functions.php
@@ -426,7 +426,7 @@ function assigner_organisateur_automatiquement($post_id, $post)
   $user = get_userdata($auteur_id);
 
   // Accepte organisateur ET organisateur_creation
-  if (array_intersect((array) $user->roles, ['organisateur', 'organisateur_creation'])) {
+  if (array_intersect((array) $user->roles, [ROLE_ORGANISATEUR, ROLE_ORGANISATEUR_CREATION])) {
     update_field('organisateur_id', $auteur_id, $post_id);
   } else {
     error_log("⚠️ Avertissement : L'auteur {$auteur_id} n'a pas un rôle valide (organisateur ou organisateur_creation).");
@@ -769,7 +769,7 @@ function forcer_relation_enigme_dans_chasse_si_absente(int $enigme_id): void
  */
 function verifier_et_synchroniser_cache_enigmes_si_autorise(int $chasse_id): void
 {
-  if (!current_user_can('administrator') && !current_user_can('organisateur') && !current_user_can('organisateur_creation')) {
+  if (!current_user_can('administrator') && !current_user_can(ROLE_ORGANISATEUR) && !current_user_can(ROLE_ORGANISATEUR_CREATION)) {
     return;
   }
 

--- a/inc/user-functions.php
+++ b/inc/user-functions.php
@@ -432,7 +432,7 @@ function ajouter_role_organisateur_creation($post_id, $post, $update) {
 
     // 🔹 Vérifie si l'utilisateur est "subscriber" avant de lui attribuer "organisateur_creation"
     if (in_array('subscriber', $user->roles, true)) {
-        $user->add_role('organisateur_creation'); // ✅ Ajoute le rôle sans retirer "subscriber"
+        $user->add_role(ROLE_ORGANISATEUR_CREATION); // ✅ Ajoute le rôle sans retirer "subscriber"
         error_log("✅ L'utilisateur $user_id a maintenant aussi le rôle 'organisateur_creation'.");
     }
 }

--- a/single-enigme.php
+++ b/single-enigme.php
@@ -31,7 +31,7 @@ verifier_ou_mettre_a_jour_cache_complet($enigme_id);
 $enigme_complete = (bool) get_field('enigme_cache_complet', $enigme_id);
 if (
   $edition_active &&
-  current_user_can('organisateur_creation') &&
+  current_user_can(ROLE_ORGANISATEUR_CREATION) &&
   !$enigme_complete &&
   !isset($_GET['edition'])
 ) {

--- a/single-organisateur.php
+++ b/single-organisateur.php
@@ -21,7 +21,7 @@ $organisateur_id = $post->ID;
 $user_id = get_current_user_id();
 $roles = (array) wp_get_current_user()->roles;
 $is_owner = $user_id && (int) get_post_field('post_author', $organisateur_id) === $user_id;
-if ($is_owner && in_array('organisateur_creation', $roles, true)) {
+if ($is_owner && in_array(ROLE_ORGANISATEUR_CREATION, $roles, true)) {
     verifier_ou_mettre_a_jour_cache_complet($organisateur_id);
 }
 $peut_modifier = utilisateur_peut_modifier_post($organisateur_id);

--- a/template-parts/enigme/chasse-partial-boucle-enigmes.php
+++ b/template-parts/enigme/chasse-partial-boucle-enigmes.php
@@ -42,7 +42,7 @@ $has_enigmes = !empty($posts_visibles);
     $cta = get_cta_enigme($enigme_id);
 
     $roles = wp_get_current_user()->roles;
-    $est_orga = array_intersect($roles, ['organisateur', 'organisateur_creation']);
+    $est_orga = array_intersect($roles, [ROLE_ORGANISATEUR, ROLE_ORGANISATEUR_CREATION]);
     $voir_bordure = !empty($est_orga) && utilisateur_est_organisateur_associe_a_chasse($utilisateur_id, $chasse_id);
     $classe_completion = '';
     if ($voir_bordure) {

--- a/template-parts/organisateur/organisateur-edition-main.php
+++ b/template-parts/organisateur/organisateur-edition-main.php
@@ -10,11 +10,11 @@ $peut_editer     = utilisateur_peut_editer_champs($organisateur_id);
 // User
 $current_user = wp_get_current_user();
 $roles = (array) $current_user->roles;
-$profil_expanded = array_intersect($roles, ['organisateur_creation', 'abonne']);
+$profil_expanded = array_intersect($roles, [ROLE_ORGANISATEUR_CREATION, 'abonne']);
 $profil_expanded = !empty($profil_expanded);
 $infos_expanded = !$profil_expanded;
 $cache_complet  = get_field('organisateur_cache_complet', $organisateur_id);
-$edition_active = in_array('organisateur_creation', $roles) && !$cache_complet;
+$edition_active = in_array(ROLE_ORGANISATEUR_CREATION, $roles) && !$cache_complet;
 
 // Post
 $titre        = get_post_field('post_title', $organisateur_id);

--- a/template-parts/organisateur/organisateur-partial-boucle-chasses.php
+++ b/template-parts/organisateur/organisateur-partial-boucle-chasses.php
@@ -22,7 +22,7 @@ $posts   = array_values(array_filter($posts, function ($post) use ($user_id) {
     <?php
     $chasse_id = $post->ID;
     $roles = wp_get_current_user()->roles;
-    $est_orga = array_intersect($roles, ['organisateur', 'organisateur_creation']);
+    $est_orga = array_intersect($roles, [ROLE_ORGANISATEUR, ROLE_ORGANISATEUR_CREATION]);
     $voir_bordure = !empty($est_orga) && utilisateur_est_organisateur_associe_a_chasse(get_current_user_id(), $chasse_id);
     $classe_completion = '';
     if ($voir_bordure) {

--- a/template-parts/organisateur/organisateur-partial-contact-form.php
+++ b/template-parts/organisateur/organisateur-partial-contact-form.php
@@ -35,7 +35,7 @@ $organisateur_statut = get_post_status($organisateur_id);
 $est_en_creation = (
     $organisateur_statut === 'pending' &&
     $current_user_id === $organisateur_auteur &&
-    in_array('organisateur_creation', (array) $current_user->roles)
+    in_array(ROLE_ORGANISATEUR_CREATION, (array) $current_user->roles)
 );
 
 get_header();

--- a/templates/admin/organisateurs.php
+++ b/templates/admin/organisateurs.php
@@ -13,7 +13,7 @@ $logout_url = wc_get_account_endpoint_url('customer-logout'); // Lien déconnexi
 
 
 // Récupérer tous les utilisateurs ayant le rôle "organisateur_creation"
-$utilisateurs = get_users(['role' => 'organisateur_creation']);
+$utilisateurs = get_users(['role' => ROLE_ORGANISATEUR_CREATION]);
 
 $organisateurs_liste = []; // Stocker les résultats trouvés
 

--- a/woocommerce/myaccount/my-account.php
+++ b/woocommerce/myaccount/my-account.php
@@ -12,7 +12,7 @@ if (isset($_GET['notice']) && $_GET['notice'] === 'profil_verification') {
 
 if ( in_array('administrator', $roles_utilisateur) ) {
     require 'admin.php';
-} elseif ( array_intersect(['organisateur', 'organisateur_creation'], $roles_utilisateur) ) {
+} elseif ( array_intersect([ROLE_ORGANISATEUR, ROLE_ORGANISATEUR_CREATION], $roles_utilisateur) ) {
     require 'organisateur.php';
 } else {
     require 'default.php'; // 🚀 Les abonnés (subscriber) arrivent ici


### PR DESCRIPTION
## Summary
- add `inc/constants.php` defining role constants
- load constants in `functions.php`
- replace hard-coded role strings with constants across theme files

## Testing
- `php -l functions.php`
- `for f in inc/access-functions.php inc/admin-functions.php inc/chasse-functions.php inc/edition/edition-chasse.php inc/edition/edition-core.php inc/organisateur-functions.php inc/relations-functions.php inc/user-functions.php single-enigme.php single-organisateur.php template-parts/enigme/chasse-partial-boucle-enigmes.php template-parts/organisateur/organisateur-edition-main.php template-parts/organisateur/organisateur-partial-boucle-chasses.php template-parts/organisateur/organisateur-partial-contact-form.php templates/admin/organisateurs.php woocommerce/myaccount/my-account.php inc/constants.php; do php -l $f || break; done`

------
https://chatgpt.com/codex/tasks/task_e_685a93dc08988332b0308a77cc9cf00d