### PR TITLE
Add est_organisateur helper

### DIFF
--- a/inc/chasse-functions.php
+++ b/inc/chasse-functions.php
@@ -292,13 +292,7 @@ function peut_valider_chasse(int $chasse_id, int $user_id): bool
         return false;
     }
 
-    $user = get_user_by('id', $user_id);
-    if (!$user) {
-        return false;
-    }
-
-    $roles = (array) $user->roles;
-    if (!array_intersect($roles, [ROLE_ORGANISATEUR, ROLE_ORGANISATEUR_CREATION])) {
+    if (!est_organisateur($user_id)) {
         return false;
     }
 

--- a/inc/relations-functions.php
+++ b/inc/relations-functions.php
@@ -423,10 +423,8 @@ function assigner_organisateur_automatiquement($post_id, $post)
   }
 
   $auteur_id = $post->post_author;
-  $user = get_userdata($auteur_id);
 
-  // Accepte organisateur ET organisateur_creation
-  if (array_intersect((array) $user->roles, [ROLE_ORGANISATEUR, ROLE_ORGANISATEUR_CREATION])) {
+  if (est_organisateur($auteur_id)) {
     update_field('organisateur_id', $auteur_id, $post_id);
   } else {
     error_log("⚠️ Avertissement : L'auteur {$auteur_id} n'a pas un rôle valide (organisateur ou organisateur_creation).");

--- a/template-parts/enigme/chasse-partial-boucle-enigmes.php
+++ b/template-parts/enigme/chasse-partial-boucle-enigmes.php
@@ -41,9 +41,8 @@ $has_enigmes = !empty($posts_visibles);
     $statut_utilisateur = enigme_get_statut_utilisateur($enigme_id, $utilisateur_id);
     $cta = get_cta_enigme($enigme_id);
 
-    $roles = wp_get_current_user()->roles;
-    $est_orga = array_intersect($roles, [ROLE_ORGANISATEUR, ROLE_ORGANISATEUR_CREATION]);
-    $voir_bordure = !empty($est_orga) && utilisateur_est_organisateur_associe_a_chasse($utilisateur_id, $chasse_id);
+    $est_orga = est_organisateur();
+    $voir_bordure = $est_orga && utilisateur_est_organisateur_associe_a_chasse($utilisateur_id, $chasse_id);
     $classe_completion = '';
     if ($voir_bordure) {
       verifier_ou_mettre_a_jour_cache_complet($enigme_id);

--- a/template-parts/organisateur/organisateur-partial-boucle-chasses.php
+++ b/template-parts/organisateur/organisateur-partial-boucle-chasses.php
@@ -21,9 +21,8 @@ $posts   = array_values(array_filter($posts, function ($post) use ($user_id) {
   <?php foreach ($posts as $post) : ?>
     <?php
     $chasse_id = $post->ID;
-    $roles = wp_get_current_user()->roles;
-    $est_orga = array_intersect($roles, [ROLE_ORGANISATEUR, ROLE_ORGANISATEUR_CREATION]);
-    $voir_bordure = !empty($est_orga) && utilisateur_est_organisateur_associe_a_chasse(get_current_user_id(), $chasse_id);
+    $est_orga = est_organisateur();
+    $voir_bordure = $est_orga && utilisateur_est_organisateur_associe_a_chasse(get_current_user_id(), $chasse_id);
     $classe_completion = '';
     if ($voir_bordure) {
       verifier_ou_mettre_a_jour_cache_complet($chasse_id);

--- a/tests/AccessFunctionsTest.php
+++ b/tests/AccessFunctionsTest.php
@@ -1,0 +1,35 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/bootstrap.php';
+
+class AccessFunctionsTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        global $mock_users, $current_user_id;
+        $mock_users = [];
+        $current_user_id = 0;
+    }
+
+    public function test_est_organisateur_role_principal()
+    {
+        global $mock_users;
+        $mock_users[1] = (object) ['ID' => 1, 'roles' => [ROLE_ORGANISATEUR]];
+        $this->assertTrue(est_organisateur(1));
+    }
+
+    public function test_est_organisateur_role_creation()
+    {
+        global $mock_users;
+        $mock_users[2] = (object) ['ID' => 2, 'roles' => [ROLE_ORGANISATEUR_CREATION]];
+        $this->assertTrue(est_organisateur(2));
+    }
+
+    public function test_est_organisateur_false_for_other_role()
+    {
+        global $mock_users;
+        $mock_users[3] = (object) ['ID' => 3, 'roles' => ['subscriber']];
+        $this->assertFalse(est_organisateur(3));
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,41 @@
+<?php
+// Minimal bootstrap for testing access helper
+if (!defined('ABSPATH')) {
+    define('ABSPATH', __DIR__ . '/..');
+}
+
+// Dummy WordPress hook functions
+if (!function_exists('add_action')) {
+    function add_action(...$args) {}
+}
+if (!function_exists('add_filter')) {
+    function add_filter(...$args) {}
+}
+if (!function_exists('add_rewrite_rule')) {
+    function add_rewrite_rule(...$args) {}
+}
+
+// Minimal WP user functions for tests
+$mock_users = [];
+$current_user_id = 0;
+
+if (!function_exists('get_current_user_id')) {
+    function get_current_user_id() {
+        global $current_user_id;
+        return $current_user_id;
+    }
+}
+if (!function_exists('get_userdata')) {
+    function get_userdata($id) {
+        global $mock_users;
+        return $mock_users[$id] ?? null;
+    }
+}
+if (!function_exists('get_user_by')) {
+    function get_user_by($field, $id) {
+        return get_userdata($id);
+    }
+}
+
+require_once __DIR__ . '/../inc/constants.php';
+require_once __DIR__ . '/../inc/access-functions.php';

--- a/woocommerce/myaccount/my-account.php
+++ b/woocommerce/myaccount/my-account.php
@@ -12,7 +12,7 @@ if (isset($_GET['notice']) && $_GET['notice'] === 'profil_verification') {
 
 if ( in_array('administrator', $roles_utilisateur) ) {
     require 'admin.php';
-} elseif ( array_intersect([ROLE_ORGANISATEUR, ROLE_ORGANISATEUR_CREATION], $roles_utilisateur) ) {
+} elseif ( est_organisateur($current_user->ID) ) {
     require 'organisateur.php';
 } else {
     require 'default.php'; // 🚀 Les abonnés (subscriber) arrivent ici


### PR DESCRIPTION
## Summary
- add `est_organisateur` helper in `inc/access-functions.php`
- use it in role checks across theme
- update relation assignment logic
- update my-account routing
- add unit tests for the helper

## Testing
- `phpunit --bootstrap tests/bootstrap.php tests/AccessFunctionsTest.php`

------
https://chatgpt.com/codex/tasks/task_e_685a95f364888332ba8730e259e7ab2d