### PR TITLE
Add cat_debug wrapper and conditional logging

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -56,6 +56,7 @@ add_action('wp_enqueue_scripts', function () {
 $inc_path = get_stylesheet_directory() . '/inc/';
 
 require_once $inc_path . 'constants.php';
+require_once $inc_path . 'utils.php';
 
 require_once $inc_path . 'shortcodes-init.php';
 require_once $inc_path . 'enigme-functions.php';

--- a/inc/constants.php
+++ b/inc/constants.php
@@ -3,3 +3,11 @@ defined( 'ABSPATH' ) || exit;
 
 const ROLE_ORGANISATEUR = 'organisateur';
 const ROLE_ORGANISATEUR_CREATION = 'organisateur_creation';
+
+// --------------------------------------------------
+// 🔧 Debug / Logging
+// --------------------------------------------------
+// Change CAT_DEBUG_VERBOSE to true to enable verbose logging.
+if (!defined('CAT_DEBUG_VERBOSE')) {
+    define('CAT_DEBUG_VERBOSE', false);
+}

--- a/inc/edition/edition-chasse.php
+++ b/inc/edition/edition-chasse.php
@@ -105,15 +105,15 @@ function creer_chasse_et_rediriger_si_appel()
   $user_id    = (int) $user->ID;
   $roles      = (array) $user->roles;
 
-  error_log("👤 Utilisateur connecté : {$user_id}");
+  cat_debug("👤 Utilisateur connecté : {$user_id}");
 
   // 📎 Récupération de l'organisateur lié
   $organisateur_id = get_organisateur_from_user($user_id);
   if (!$organisateur_id) {
-    error_log("🛑 Aucun organisateur trouvé pour l'utilisateur {$user_id}");
+    cat_debug("🛑 Aucun organisateur trouvé pour l'utilisateur {$user_id}");
     wp_die('Aucun organisateur associé.');
   }
-  error_log("✅ Organisateur trouvé : {$organisateur_id}");
+  cat_debug("✅ Organisateur trouvé : {$organisateur_id}");
 
   // 🔒 Vérification des droits de création
   if (!current_user_can('administrator') && !current_user_can(ROLE_ORGANISATEUR)) {
@@ -135,11 +135,11 @@ function creer_chasse_et_rediriger_si_appel()
   ]);
 
   if (is_wp_error($post_id)) {
-    error_log("🛑 Erreur création post : " . $post_id->get_error_message());
+    cat_debug("🛑 Erreur création post : " . $post_id->get_error_message());
     wp_die('Erreur lors de la création de la chasse.');
   }
 
-  error_log("✅ Chasse créée avec l’ID : {$post_id}");
+  cat_debug("✅ Chasse créée avec l’ID : {$post_id}");
 
   update_field('chasse_principale_image', 3902, $post_id);
 
@@ -164,7 +164,7 @@ function creer_chasse_et_rediriger_si_appel()
 
   // 🚀 Redirection vers la prévisualisation frontale avec panneau ouvert
   $preview_url = add_query_arg('edition', 'open', get_preview_post_link($post_id));
-  error_log("➡️ Redirection vers : {$preview_url}");
+  cat_debug("➡️ Redirection vers : {$preview_url}");
   wp_redirect($preview_url);
   exit;
 }
@@ -227,7 +227,7 @@ function modifier_champ_chasse()
   // 🛡️ Initialisation sécurisée du groupe caracteristiques
   $groupe_actuel = get_field('caracteristiques', $post_id);
   if (!is_array($groupe_actuel)) {
-    error_log("⚠️ Groupe caracteristiques vide ou absent — tentative de réinitialisation forcée.");
+    cat_debug("⚠️ Groupe caracteristiques vide ou absent — tentative de réinitialisation forcée.");
 
     $groupe_init = [
       'chasse_infos_date_debut'        => '',
@@ -242,9 +242,9 @@ function modifier_champ_chasse()
 
     $ok_init = update_field('caracteristiques', $groupe_init, $post_id);
     if (!$ok_init) {
-      error_log("❌ Groupe ACF toujours introuvable après tentative d'initialisation : caracteristiques");
+      cat_debug("❌ Groupe ACF toujours introuvable après tentative d'initialisation : caracteristiques");
     } else {
-      error_log("✅ Groupe caracteristiques initialisé manuellement pour post #$post_id");
+      cat_debug("✅ Groupe caracteristiques initialisé manuellement pour post #$post_id");
     }
   }
 
@@ -302,7 +302,7 @@ function modifier_champ_chasse()
     $ok = update_field('caracteristiques', $groupe, $post_id);
     $carac_maj = get_field('caracteristiques', $post_id);
     $mode_continue = empty($carac_maj['chasse_infos_duree_illimitee']);
-    error_log("🧪 Illimitée (après MAJ) = " . var_export($carac_maj['chasse_infos_duree_illimitee'], true));
+    cat_debug("🧪 Illimitée (après MAJ) = " . var_export($carac_maj['chasse_infos_duree_illimitee'], true));
 
 
     if ($ok) {
@@ -324,14 +324,14 @@ function modifier_champ_chasse()
   }
 
   if ($champ === 'caracteristiques.chasse_infos_cout_points') {
-    error_log("🧪 Correction tentative : MAJ cout_points → valeur = {$valeur}");
+    cat_debug("🧪 Correction tentative : MAJ cout_points → valeur = {$valeur}");
     $ok = mettre_a_jour_sous_champ_group($post_id, 'caracteristiques', 'chasse_infos_cout_points', (int) $valeur);
     if ($ok) {
-      error_log("✅ MAJ réussie pour chasse_infos_cout_points");
+      cat_debug("✅ MAJ réussie pour chasse_infos_cout_points");
       $champ_valide = true;
       $doit_recalculer_statut = true;
     } else {
-      error_log("❌ MAJ échouée malgré nom exact");
+      cat_debug("❌ MAJ échouée malgré nom exact");
     }
   }
 
@@ -342,7 +342,7 @@ function modifier_champ_chasse()
     $liste_enigmes = recuperer_enigmes_associees($post_id);
     if (!empty($liste_enigmes)) {
       foreach ($liste_enigmes as $enigme_id) {
-        error_log("🧩 Planification/déplacement : énigme #$enigme_id");
+        cat_debug("🧩 Planification/déplacement : énigme #$enigme_id");
         planifier_ou_deplacer_pdf_solution_immediatement($enigme_id);
       }
     }
@@ -398,7 +398,7 @@ function modifier_champ_chasse()
     wp_cache_delete($post_id, 'post');
     sleep(1); // donne une chance au cache + update ACF de se stabiliser
     $caracteristiques = get_field('caracteristiques', $post_id);
-    error_log("[🔁 RELOAD] Relecture avant recalcul : " . json_encode($caracteristiques));
+    cat_debug("[🔁 RELOAD] Relecture avant recalcul : " . json_encode($caracteristiques));
     mettre_a_jour_statuts_chasse($post_id);
   }
   wp_send_json_success($reponse);
@@ -440,10 +440,10 @@ function assigner_organisateur_a_chasse($post_id, $post)
 
     // Vérification après mise à jour
     if (!$resultat) {
-      error_log("🛑 Échec de la mise à jour de organisateur_chasse pour la chasse $post_id");
+      cat_debug("🛑 Échec de la mise à jour de organisateur_chasse pour la chasse $post_id");
     }
   } else {
-    error_log("🛑 Aucun organisateur trouvé pour la chasse $post_id (aucune mise à jour)");
+    cat_debug("🛑 Aucun organisateur trouvé pour la chasse $post_id (aucune mise à jour)");
   }
 }
 add_action('save_post_chasse', 'assigner_organisateur_a_chasse', 20, 2);

--- a/inc/edition/edition-core.php
+++ b/inc/edition/edition-core.php
@@ -484,20 +484,20 @@ function convertir_en_datetime(?string $date_string, array $formats = [
 ]): ?DateTime
 {
   if (empty($date_string)) {
-    error_log("🚫 Date vide ou non fournie.");
+    cat_debug("🚫 Date vide ou non fournie.");
     return null;
   }
 
   foreach ($formats as $format) {
     $date_obj = DateTime::createFromFormat($format, $date_string);
     if ($date_obj) {
-      error_log("✅ Date '{$date_string}' convertie avec le format : {$format}");
+      cat_debug("✅ Date '{$date_string}' convertie avec le format : {$format}");
       return $date_obj;
     }
   }
 
   // 🚨 Ajout d'un fallback pour éviter le crash
-  error_log("⚠️ Échec de conversion pour la date : '{$date_string}'. Formats testés : " . implode(', ', $formats));
+  cat_debug("⚠️ Échec de conversion pour la date : '{$date_string}'. Formats testés : " . implode(', ', $formats));
   return new DateTime('now', new DateTimeZone('UTC')); // Retourne la date actuelle au lieu de `null`
 }
 
@@ -549,7 +549,7 @@ function mettre_a_jour_relation_acf($post_id, $relation_field, $related_post_id,
 {
   // Vérifier les paramètres requis
   if (empty($post_id) || empty($relation_field) || empty($related_post_id)) {
-    error_log("🛑 ERREUR : Paramètres manquants pour mettre à jour la relation ACF.");
+    cat_debug("🛑 ERREUR : Paramètres manquants pour mettre à jour la relation ACF.");
     return false;
   }
 
@@ -579,7 +579,7 @@ function mettre_a_jour_relation_acf($post_id, $relation_field, $related_post_id,
     return true;
   }
 
-  error_log("🛑 ERREUR : La mise à jour de {$full_field_name} a échoué dans mettre_a_jour_relation_acf().");
+  cat_debug("🛑 ERREUR : La mise à jour de {$full_field_name} a échoué dans mettre_a_jour_relation_acf().");
   return false;
 }
 
@@ -604,7 +604,7 @@ function mettre_a_jour_relation_acf($post_id, $relation_field, $related_post_id,
 function modifier_relation_acf($post_id, $relation_field, $related_post_id, $acf_key, $action = 'add')
 {
   if (empty($post_id) || empty($relation_field) || empty($related_post_id)) {
-    error_log("🛑 ERREUR : Paramètres manquants pour modifier la relation ACF.");
+    cat_debug("🛑 ERREUR : Paramètres manquants pour modifier la relation ACF.");
     return false;
   }
 
@@ -621,10 +621,10 @@ function modifier_relation_acf($post_id, $relation_field, $related_post_id, $acf
       update_post_meta($post_id, $relation_field, $current_value);
       update_post_meta($post_id, "_{$relation_field}", $acf_key);
 
-      error_log("✅ Relation ajoutée avec succès : {$relation_field} → {$related_post_id}.");
+      cat_debug("✅ Relation ajoutée avec succès : {$relation_field} → {$related_post_id}.");
       return true;
     }
-    error_log("ℹ️ Relation déjà existante : {$relation_field} → {$related_post_id}. Aucune modification.");
+    cat_debug("ℹ️ Relation déjà existante : {$relation_field} → {$related_post_id}. Aucune modification.");
   } elseif ($action === 'remove') {
     // 📌 Supprimer uniquement si l'ID est présent
     if (in_array($related_post_id, $current_value)) {
@@ -632,12 +632,12 @@ function modifier_relation_acf($post_id, $relation_field, $related_post_id, $acf
       update_post_meta($post_id, $relation_field, $current_value);
       update_post_meta($post_id, "_{$relation_field}", $acf_key);
 
-      error_log("✅ Relation supprimée avec succès : {$relation_field} → {$related_post_id}.");
+      cat_debug("✅ Relation supprimée avec succès : {$relation_field} → {$related_post_id}.");
       return true;
     }
-    error_log("ℹ️ La relation à supprimer n'existait pas : {$relation_field} → {$related_post_id}.");
+    cat_debug("ℹ️ La relation à supprimer n'existait pas : {$relation_field} → {$related_post_id}.");
   } else {
-    error_log("🛑 ERREUR : Action inconnue '{$action}' pour modifier_relation_acf().");
+    cat_debug("🛑 ERREUR : Action inconnue '{$action}' pour modifier_relation_acf().");
   }
 
   return false;
@@ -659,7 +659,7 @@ function modifier_relation_acf($post_id, $relation_field, $related_post_id, $acf
 function mettre_a_jour_sous_champ_group(int $post_id, string $group_key_or_name, string $subfield_name, $new_value): bool
 {
   if (!$post_id || !$group_key_or_name || !$subfield_name) {
-    error_log('❌ Paramètres manquants dans mettre_a_jour_sous_champ_group()');
+    cat_debug('❌ Paramètres manquants dans mettre_a_jour_sous_champ_group()');
     return false;
   }
 
@@ -669,11 +669,11 @@ function mettre_a_jour_sous_champ_group(int $post_id, string $group_key_or_name,
 
   if (!$group_object || empty($group_object['sub_fields'])) {
     // Tentative d'initialisation minimale si jamais le groupe n'est pas encore enregistré
-    error_log("⚠️ Groupe $group_key_or_name vide ou absent — tentative de réinitialisation forcée.");
+    cat_debug("⚠️ Groupe $group_key_or_name vide ou absent — tentative de réinitialisation forcée.");
     update_field($group_key_or_name, [], $post_id);
     $group_object = get_field_object($group_key_or_name, $post_id);
     if (!$group_object || empty($group_object['sub_fields'])) {
-      error_log("❌ Groupe ACF toujours introuvable après tentative d'initialisation : $group_key_or_name");
+      cat_debug("❌ Groupe ACF toujours introuvable après tentative d'initialisation : $group_key_or_name");
       return false;
     }
   }
@@ -727,7 +727,7 @@ function mettre_a_jour_sous_champ_group(int $post_id, string $group_key_or_name,
   }
 
   delete_field($group_object['name'], $post_id);
-  error_log('[DEBUG] Données envoyées à update_field() pour groupe ' . $group_object['name'] . ' : ' . json_encode($champ_a_enregistrer));
+  cat_debug('[DEBUG] Données envoyées à update_field() pour groupe ' . $group_object['name'] . ' : ' . json_encode($champ_a_enregistrer));
 
   $ok = update_field($group_object['name'], $champ_a_enregistrer, $post_id);
   clean_post_cache($post_id);
@@ -736,10 +736,10 @@ function mettre_a_jour_sous_champ_group(int $post_id, string $group_key_or_name,
   $groupe_verif = get_field($group_object['name'], $post_id);
 
   $str_valeur = is_array($new_value) ? json_encode($new_value) : $new_value;
-  error_log("🧪 [DEBUG ACF] Mise à jour demandée : $group_key_or_name.$subfield_name → $str_valeur (post #$post_id)");
+  cat_debug("🧪 [DEBUG ACF] Mise à jour demandée : $group_key_or_name.$subfield_name → $str_valeur (post #$post_id)");
 
   $groupe_verif = get_field($group_key_or_name, $post_id);
-  error_log("📥 [DEBUG ACF] Relecture après update : " . json_encode($groupe_verif));
+  cat_debug("📥 [DEBUG ACF] Relecture après update : " . json_encode($groupe_verif));
 
 
 
@@ -761,6 +761,6 @@ function mettre_a_jour_sous_champ_group(int $post_id, string $group_key_or_name,
     return wp_strip_all_tags($str_new) === wp_strip_all_tags($str_relue);
   }
 
-  error_log("❌ Échec de vérification pour $subfield_name dans {$group_object['name']}");
+  cat_debug("❌ Échec de vérification pour $subfield_name dans {$group_object['name']}");
   return false;
 }

--- a/inc/edition/edition-enigme.php
+++ b/inc/edition/edition-enigme.php
@@ -706,9 +706,9 @@ add_action('acf/save_post', function ($post_id) {
   );
 
   if ($success) {
-    error_log("✅ Énigme $post_id ajoutée à la chasse $chasse_id");
+    cat_debug("✅ Énigme $post_id ajoutée à la chasse $chasse_id");
   } else {
-    error_log("❌ Échec ajout énigme $post_id à la chasse $chasse_id");
+    cat_debug("❌ Échec ajout énigme $post_id à la chasse $chasse_id");
   }
 }, 20);
 
@@ -755,7 +755,7 @@ function nettoyer_relations_orphelines()
     // 🔥 Si on a supprimé des IDs, mettre à jour la base
     if (count($relations_nettoyees) !== count($relations)) {
       update_post_meta($post_id, 'champs_caches_enigmes_associees', $relations_nettoyees);
-      error_log("✅ Relations nettoyées pour la chasse ID {$post_id} : " . print_r($relations_nettoyees, true));
+      cat_debug("✅ Relations nettoyées pour la chasse ID {$post_id} : " . print_r($relations_nettoyees, true));
     }
   }
 }

--- a/inc/edition/edition-organisateur.php
+++ b/inc/edition/edition-organisateur.php
@@ -54,14 +54,14 @@ function organisateur_get_liens_actifs(int $organisateur_id): array
 function creer_organisateur_pour_utilisateur($user_id)
 {
   if (!is_int($user_id) || $user_id <= 0) {
-    error_log("❌ ID utilisateur invalide : $user_id");
+    cat_debug("❌ ID utilisateur invalide : $user_id");
     return null;
   }
 
   // Vérifie si un organisateur est déjà lié à cet utilisateur
   $existant = get_organisateur_from_user($user_id);
   if ($existant) {
-    error_log("ℹ️ Un organisateur existe déjà pour l'utilisateur $user_id (ID : $existant)");
+    cat_debug("ℹ️ Un organisateur existe déjà pour l'utilisateur $user_id (ID : $existant)");
     // Renvoie simplement l'ID existant pour éviter un échec de confirmation
     return (int) $existant;
   }
@@ -75,7 +75,7 @@ function creer_organisateur_pour_utilisateur($user_id)
   ]);
 
   if (is_wp_error($post_id)) {
-    error_log("❌ Erreur création organisateur : " . $post_id->get_error_message());
+    cat_debug("❌ Erreur création organisateur : " . $post_id->get_error_message());
     return null;
   }
 
@@ -96,7 +96,7 @@ function creer_organisateur_pour_utilisateur($user_id)
 
   update_field('profil_public', $profil_public, $post_id);
 
-  error_log("✅ Organisateur créé (pending) pour user $user_id : post ID $post_id");
+  cat_debug("✅ Organisateur créé (pending) pour user $user_id : post ID $post_id");
 
   return $post_id;
 }
@@ -361,8 +361,8 @@ add_action('wp_ajax_modifier_titre_organisateur', 'modifier_titre_organisateur')
  */
 function modifier_titre_organisateur()
 {
-  error_log('== FICHIER AJAX ORGANISATEUR CHARGÉ ==');
-  error_log('== ENTREE AJAX modifier_titre_organisateur ==');
+  cat_debug('== FICHIER AJAX ORGANISATEUR CHARGÉ ==');
+  cat_debug('== ENTREE AJAX modifier_titre_organisateur ==');
 
   if (!is_user_logged_in()) {
     wp_send_json_error('non_connecte');
@@ -394,16 +394,16 @@ function modifier_titre_organisateur()
     'post_title' => $titre,
   ], true);
 
-  error_log("=== DEBUG TITRE ===");
-  error_log("Résultat : " . print_r($result, true));
+  cat_debug("=== DEBUG TITRE ===");
+  cat_debug("Résultat : " . print_r($result, true));
   $post = get_post($organisateur_id);
-  error_log("Titre réel en base : " . $post->post_title);
+  cat_debug("Titre réel en base : " . $post->post_title);
 
 
-  error_log("=== MODIF ORGANISATEUR ===");
-  error_log("User ID: " . $user_id);
-  error_log("Post ID: " . $organisateur_id);
-  error_log("Titre envoyé : " . $titre);
+  cat_debug("=== MODIF ORGANISATEUR ===");
+  cat_debug("User ID: " . $user_id);
+  cat_debug("Post ID: " . $organisateur_id);
+  cat_debug("Titre envoyé : " . $titre);
 
 
 

--- a/inc/edition/edition-securite.php
+++ b/inc/edition/edition-securite.php
@@ -73,7 +73,7 @@ function injecter_htaccess_protection_images_enigme($post_id, bool $forcer = fal
 {
   $post_id = (int) $post_id;
   if ($post_id <= 0 || get_post_type($post_id) !== 'enigme') {
-    error_log("❌ Post ID invalide ou type incorrect pour htaccess : {$post_id}");
+    cat_debug("❌ Post ID invalide ou type incorrect pour htaccess : {$post_id}");
     return false;
   }
 
@@ -82,24 +82,24 @@ function injecter_htaccess_protection_images_enigme($post_id, bool $forcer = fal
 
   if (!is_dir($base_dir)) {
     if (!wp_mkdir_p($base_dir)) {
-      error_log("❌ Impossible de créer le dossier {$base_dir}");
+      cat_debug("❌ Impossible de créer le dossier {$base_dir}");
       return false;
     }
-    error_log("📁 Dossier créé : {$base_dir}");
+    cat_debug("📁 Dossier créé : {$base_dir}");
   }
 
   $fichier_htaccess = $base_dir . '/.htaccess';
   $fichier_tmp = $fichier_htaccess . '.tmp';
 
   if (!$forcer && file_exists($fichier_htaccess)) {
-    error_log("ℹ️ .htaccess déjà présent pour énigme {$post_id}, pas de réécriture.");
+    cat_debug("ℹ️ .htaccess déjà présent pour énigme {$post_id}, pas de réécriture.");
     return true;
   }
 
   // Supprime le fichier temporaire si présent
   if (file_exists($fichier_tmp)) {
     unlink($fichier_tmp);
-    error_log("🧹 Fichier temporaire .htaccess.tmp supprimé");
+    cat_debug("🧹 Fichier temporaire .htaccess.tmp supprimé");
   }
 
   $contenu = <<<HTACCESS
@@ -120,11 +120,11 @@ RewriteRule . - [L]
 HTACCESS;
 
   if (file_put_contents($fichier_htaccess, $contenu, LOCK_EX) === false) {
-    error_log("❌ Échec d’écriture du fichier .htaccess pour énigme {$post_id}");
+    cat_debug("❌ Échec d’écriture du fichier .htaccess pour énigme {$post_id}");
     return false;
   }
 
-  error_log("✅ .htaccess injecté avec succès pour énigme {$post_id}");
+  cat_debug("✅ .htaccess injecté avec succès pour énigme {$post_id}");
   return true;
 }
 
@@ -168,8 +168,8 @@ add_action('acf/save_post', 'verrouiller_visuels_enigme_si_nouveau_upload', 20);
  */
 function filtrer_visuels_enigme_front($images, $post_id, $field)
 {
-  error_log('[DEBUG] filtre gallery appelé pour post ID : ' . $post_id);
-  error_log("[✔️ filtre ACF gallery actif] post_id = $post_id | champ = " . ($field['name'] ?? 'inconnu'));
+  cat_debug('[DEBUG] filtre gallery appelé pour post ID : ' . $post_id);
+  cat_debug("[✔️ filtre ACF gallery actif] post_id = $post_id | champ = " . ($field['name'] ?? 'inconnu'));
 
 
   if (is_admin()) return $images;
@@ -219,16 +219,16 @@ function desactiver_htaccess_temporairement_enigme()
   // ✅ Si .htaccess existe et pas déjà désactivé
   if (file_exists($fichier_htaccess)) {
     if (!@rename($fichier_htaccess, $fichier_tmp)) {
-      error_log("❌ Impossible de renommer .htaccess vers .tmp pour énigme {$post_id}");
+      cat_debug("❌ Impossible de renommer .htaccess vers .tmp pour énigme {$post_id}");
       wp_send_json_error("Erreur désactivation");
     }
-    error_log("✅ .htaccess désactivé temporairement pour énigme {$post_id}");
+    cat_debug("✅ .htaccess désactivé temporairement pour énigme {$post_id}");
     $message = 'Protection désactivée (nouveau .tmp)';
   } elseif (file_exists($fichier_tmp)) {
-    error_log("ℹ️ .htaccess déjà désactivé pour énigme {$post_id} – renouvellement délai");
+    cat_debug("ℹ️ .htaccess déjà désactivé pour énigme {$post_id} – renouvellement délai");
     $message = 'Déjà désactivé – délai renouvelé';
   } else {
-    error_log("ℹ️ Aucun .htaccess à désactiver (pas encore d’image) pour énigme {$post_id}");
+    cat_debug("ℹ️ Aucun .htaccess à désactiver (pas encore d’image) pour énigme {$post_id}");
     $message = 'Aucun fichier à désactiver (pas encore d’image)';
   }
 
@@ -256,7 +256,7 @@ function reactiver_htaccess_protection_enigme_apres_save($post_id)
   $fichier_tmp = $upload_dir['basedir'] . '/_enigmes/enigme-' . $post_id . '/.htaccess.tmp';
   if (file_exists($fichier_tmp)) {
     unlink($fichier_tmp);
-    error_log("🧼 .htaccess.tmp supprimé après enregistrement de l’énigme {$post_id}");
+    cat_debug("🧼 .htaccess.tmp supprimé après enregistrement de l’énigme {$post_id}");
   }
 
   // Supprime le transient
@@ -293,14 +293,14 @@ function verifier_expiration_desactivations_htaccess()
     if ($now > $expiration) {
       if (file_exists($htaccess_tmp) && !file_exists($htaccess)) {
         if (rename($htaccess_tmp, $htaccess)) {
-          error_log("⏲️ Fallback restauration .htaccess (expiration dépassée) pour énigme {$post_id}");
+          cat_debug("⏲️ Fallback restauration .htaccess (expiration dépassée) pour énigme {$post_id}");
         } else {
-          error_log("❌ Échec restauration .htaccess depuis .tmp pour énigme {$post_id}");
+          cat_debug("❌ Échec restauration .htaccess depuis .tmp pour énigme {$post_id}");
         }
       } else {
         // sinon réécrit quand même pour être sûr
         injecter_htaccess_protection_images_enigme($post_id, true);
-        error_log("⏱️ Expiration atteinte : .htaccess réinjecté pour énigme {$post_id}");
+        cat_debug("⏱️ Expiration atteinte : .htaccess réinjecté pour énigme {$post_id}");
       }
 
       // Nettoyage
@@ -328,14 +328,14 @@ function restaurer_htaccess_si_temporairement_desactive($post_id)
   if (file_exists($htaccess)) {
     // .htaccess existe déjà, donc on peut supprimer le temporaire s’il traîne
     unlink($tmp);
-    error_log("🧹 .htaccess.tmp supprimé (déjà restauré) pour énigme {$post_id}");
+    cat_debug("🧹 .htaccess.tmp supprimé (déjà restauré) pour énigme {$post_id}");
     return;
   }
 
   if (rename($tmp, $htaccess)) {
-    error_log("🔁 .htaccess restauré depuis .tmp pour énigme {$post_id}");
+    cat_debug("🔁 .htaccess restauré depuis .tmp pour énigme {$post_id}");
   } else {
-    error_log("❌ Impossible de restaurer .htaccess depuis .tmp pour énigme {$post_id}");
+    cat_debug("❌ Impossible de restaurer .htaccess depuis .tmp pour énigme {$post_id}");
   }
 }
 
@@ -408,9 +408,9 @@ function get_expiration_htaccess_enigme()
   // ❌ Transient expiré ou absent, mais .tmp encore là → on restaure
   @unlink($fichier_htaccess); // au cas où résidu
   if (@rename($fichier_htaccess_tmp, $fichier_htaccess)) {
-    error_log("🔒 htaccess restauré automatiquement (expiration dépassée) pour énigme {$post_id}");
+    cat_debug("🔒 htaccess restauré automatiquement (expiration dépassée) pour énigme {$post_id}");
   } else {
-    error_log("⚠️ Échec restauration htaccess expirée pour énigme {$post_id}");
+    cat_debug("⚠️ Échec restauration htaccess expirée pour énigme {$post_id}");
   }
 
   delete_transient($transient_key);
@@ -433,7 +433,7 @@ add_action('wp_ajax_verrouillage_termine_enigme', function () {
 
   if (file_exists($dossier . '/.htaccess.tmp') && !file_exists($dossier . '/.htaccess')) {
     rename($dossier . '/.htaccess.tmp', $dossier . '/.htaccess');
-    error_log("🔁 .htaccess restauré depuis .tmp (expiration JS) pour énigme #$post_id");
+    cat_debug("🔁 .htaccess restauré depuis .tmp (expiration JS) pour énigme #$post_id");
   }
 
   delete_transient('htaccess_timeout_enigme_' . $post_id);
@@ -458,13 +458,13 @@ add_action('wp_ajax_verrouillage_termine_enigme', function () {
  */
 function purger_htaccess_temp_enigmes()
 {
-  error_log('🟡 CRON lancé : purge htaccess');
+  cat_debug('🟡 CRON lancé : purge htaccess');
 
   $upload_dir = wp_upload_dir();
   $base = $upload_dir['basedir'] . '/_enigmes';
 
   if (!is_dir($base)) {
-    error_log('❌ Base des énigmes introuvable');
+    cat_debug('❌ Base des énigmes introuvable');
     return;
   }
 
@@ -479,20 +479,20 @@ function purger_htaccess_temp_enigmes()
     }
 
     $transient = get_transient('htaccess_timeout_enigme_' . $post_id);
-    error_log("⏱️ Transient actuel pour $post_id : " . var_export($transient, true));
+    cat_debug("⏱️ Transient actuel pour $post_id : " . var_export($transient, true));
 
     if (!$transient || $transient < time()) {
-      error_log("🟥 Transient expiré ou absent pour $post_id → tentative restauration");
+      cat_debug("🟥 Transient expiré ou absent pour $post_id → tentative restauration");
 
       $fichier_final = $dossier . '/.htaccess';
       if (@rename($fichier_tmp, $fichier_final)) {
         delete_transient('htaccess_timeout_enigme_' . $post_id);
-        error_log("🟢 Restauration OK htaccess pour énigme $post_id");
+        cat_debug("🟢 Restauration OK htaccess pour énigme $post_id");
       } else {
-        error_log("⚠️ Échec restauration pour énigme $post_id");
+        cat_debug("⚠️ Échec restauration pour énigme $post_id");
       }
     } else {
-      error_log("🟩 Transient encore actif pour $post_id");
+      cat_debug("🟩 Transient encore actif pour $post_id");
     }
   }
 }

--- a/inc/statut-functions.php
+++ b/inc/statut-functions.php
@@ -93,7 +93,7 @@ function enigme_mettre_a_jour_statut_utilisateur(int $enigme_id, int $user_id, s
     ];
 
     if (!isset($priorites[$nouveau_statut])) {
-        error_log("❌ Statut utilisateur invalide : $nouveau_statut");
+        cat_debug("❌ Statut utilisateur invalide : $nouveau_statut");
         return false;
     }
 
@@ -105,7 +105,7 @@ function enigme_mettre_a_jour_statut_utilisateur(int $enigme_id, int $user_id, s
 
     // Protection : interdiction de rétrograder un joueur ayant déjà résolu l’énigme
     if (!$forcer && in_array($statut_actuel, ['resolue', 'terminee'], true)) {
-        error_log("🔒 Statut non modifié : $statut_actuel → tentative de mise à jour vers $nouveau_statut bloquée (UID: $user_id / Enigme: $enigme_id)");
+        cat_debug("🔒 Statut non modifié : $statut_actuel → tentative de mise à jour vers $nouveau_statut bloquée (UID: $user_id / Enigme: $enigme_id)");
         return false;
     }
 
@@ -399,7 +399,7 @@ function mettre_a_jour_statuts_enigmes_de_la_chasse(int $chasse_id): void
 function enigme_mettre_a_jour_etat_systeme(int $enigme_id, bool $mettre_a_jour = true, ?string $statut_chasse_forcé = null): string
 {
     if (get_post_type($enigme_id) !== 'enigme') {
-        error_log("❌ [STATUT] Post #$enigme_id n'est pas une énigme");
+        cat_debug("❌ [STATUT] Post #$enigme_id n'est pas une énigme");
         return 'cache_invalide';
     }
     $etat = 'accessible';
@@ -408,10 +408,10 @@ function enigme_mettre_a_jour_etat_systeme(int $enigme_id, bool $mettre_a_jour =
     $chasse_id = recuperer_id_chasse_associee($enigme_id);
     if (!$chasse_id || get_post_type($chasse_id) !== 'chasse') {
         $etat = 'bloquee_chasse';
-        error_log("🧩 #$enigme_id → bloquee_chasse (aucune chasse valide liée)");
+        cat_debug("🧩 #$enigme_id → bloquee_chasse (aucune chasse valide liée)");
     } else {
         $statut_chasse = $statut_chasse_forcé ?? (get_field('champs_caches', $chasse_id)['chasse_cache_statut'] ?? null);
-        error_log("🧩 #$enigme_id → chasse #$chasse_id statut = $statut_chasse");
+        cat_debug("🧩 #$enigme_id → chasse #$chasse_id statut = $statut_chasse");
 
         if (!in_array($statut_chasse, ['en_cours', 'payante', 'termine'], true)) {
             $etat = 'bloquee_chasse';
@@ -426,7 +426,7 @@ function enigme_mettre_a_jour_etat_systeme(int $enigme_id, bool $mettre_a_jour =
         $date_obj = convertir_en_datetime($date);
         if (!$date_obj || $date_obj->getTimestamp() > time()) {
             $etat = 'bloquee_date';
-            error_log("🧩 #$enigme_id → bloquee_date (accès programmé futur ou vide)");
+            cat_debug("🧩 #$enigme_id → bloquee_date (accès programmé futur ou vide)");
         }
     }
 
@@ -435,7 +435,7 @@ function enigme_mettre_a_jour_etat_systeme(int $enigme_id, bool $mettre_a_jour =
     $reponse = get_field('enigme_reponse_bonne', $enigme_id);
     if ($etat === 'accessible' && $mode === 'automatique' && !$reponse) {
         $etat = 'invalide';
-        error_log("🧩 #$enigme_id → invalide (automatique sans réponse)");
+        cat_debug("🧩 #$enigme_id → invalide (automatique sans réponse)");
     }
 
     // ✅ Mise à jour ACF si demandé
@@ -444,7 +444,7 @@ function enigme_mettre_a_jour_etat_systeme(int $enigme_id, bool $mettre_a_jour =
         if ($actuel !== $etat) {
             update_field('enigme_cache_etat_systeme', $etat, $enigme_id);
         } else {
-            error_log("⏸️ [STATUT] Pas de changement pour #$enigme_id (déjà $etat)");
+            cat_debug("⏸️ [STATUT] Pas de changement pour #$enigme_id (déjà $etat)");
         }
     }
 
@@ -752,7 +752,7 @@ function mettre_a_jour_statuts_chasse($chasse_id)
     $carac = get_field('caracteristiques', $chasse_id);
     $cache = get_field('champs_caches', $chasse_id);
     if (!$carac || !$cache) {
-        error_log("⚠️ Données manquantes pour chasse #$chasse_id : caractéristiques ou champs_caches");
+        cat_debug("⚠️ Données manquantes pour chasse #$chasse_id : caractéristiques ou champs_caches");
         return;
     }
 
@@ -854,7 +854,7 @@ function mettre_a_jour_statut_si_chasse($post_id)
         // 🔁 Supprimer le champ pour forcer une relecture propre (évite valeurs en cache)
         delete_transient("acf_field_{$post_id}_champs_caches");
 
-        error_log("🔁 Recalcul du statut via acf/save_post pour la chasse $post_id");
+        cat_debug("🔁 Recalcul du statut via acf/save_post pour la chasse $post_id");
         mettre_a_jour_statuts_chasse($post_id);
     }
 }
@@ -996,7 +996,7 @@ function forcer_statut_selon_validation_chasse($post_id, $post, $update)
     };
 
     if ($statut_wp !== $statut_attendu) {
-        error_log("⚠️ Décalage statut WP vs ACF pour chasse $post_id → WP = $statut_wp / ACF = $validation");
+        cat_debug("⚠️ Décalage statut WP vs ACF pour chasse $post_id → WP = $statut_wp / ACF = $validation");
 
         // ⛔ EN DÉVELOPPEMENT : synchronisation désactivée
         // ✅ À ACTIVER EN PROD :

--- a/inc/utils.php
+++ b/inc/utils.php
@@ -1,0 +1,24 @@
+<?php
+defined('ABSPATH') || exit;
+
+/**
+ * Logs debug messages conditionally.
+ *
+ * Use the CAT_DEBUG_VERBOSE constant or the `cat_debug_enabled` filter to
+ * control output.
+ *
+ * @param mixed $message Message to log. Arrays/objects are exported.
+ * @param bool $force    Force logging regardless of settings.
+ * @return void
+ */
+function cat_debug($message, bool $force = false): void {
+    $enabled = defined('CAT_DEBUG_VERBOSE') && CAT_DEBUG_VERBOSE;
+    $enabled = apply_filters('cat_debug_enabled', $enabled);
+
+    if ($enabled || $force) {
+        if (is_array($message) || is_object($message)) {
+            $message = print_r($message, true);
+        }
+        error_log($message);
+    }
+}


### PR DESCRIPTION
## Summary
- add a `cat_debug()` helper in new `inc/utils.php`
- provide constant `CAT_DEBUG_VERBOSE` to control debug logging
- include the utility file in `functions.php`
- replace `error_log()` with `cat_debug()` in edition and statut modules

## Testing
- `phpunit tests`

------
https://chatgpt.com/codex/tasks/task_e_685a98b5faec8332ad1336367f47d4f1