### PR TITLE
Add solution visibility helper and tests

### DIFF
--- a/template-parts/enigme/partials/enigme-partial-solution.php
+++ b/template-parts/enigme/partials/enigme-partial-solution.php
@@ -13,7 +13,7 @@ $fichier = get_field('enigme_solution_fichier', $post_id);
 $fichier_url = is_array($fichier) ? $fichier['url'] ?? '' : '';
 
 // 🚧 Placeholder pour l’instant – conditions à implémenter plus tard
-$conditions_ok = true; // TODO: vérifier chasse terminée + délai dépassé
+$conditions_ok = solution_peut_etre_affichee($post_id);
 
 if (!$conditions_ok) return;
 

--- a/tests/SolutionVisibilityTest.php
+++ b/tests/SolutionVisibilityTest.php
@@ -1,0 +1,58 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/bootstrap.php';
+
+class SolutionVisibilityTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        global $mock_posts, $mock_fields, $mock_current_time;
+        $mock_posts = [];
+        $mock_fields = [];
+        $mock_current_time = null;
+    }
+
+    public function test_solution_hidden_if_chasse_not_terminee()
+    {
+        global $mock_posts, $mock_fields;
+        $mock_posts[10] = ['post_type' => 'chasse'];
+        $mock_posts[20] = ['post_type' => 'enigme'];
+        $mock_fields[20]['enigme_chasse_associee'] = 10;
+        $mock_fields[10]['statut_chasse'] = 'En cours';
+
+        $this->assertFalse(solution_peut_etre_affichee(20));
+    }
+
+    public function test_solution_hidden_until_delay_elapsed()
+    {
+        global $mock_posts, $mock_fields, $mock_current_time;
+        $mock_posts[10] = ['post_type' => 'chasse'];
+        $mock_posts[20] = ['post_type' => 'enigme'];
+        $mock_fields[20]['enigme_chasse_associee'] = 10;
+        $mock_fields[10]['statut_chasse'] = 'Terminée';
+        $mock_fields[20]['enigme_solution_mode'] = 'delai_fin_chasse';
+        $mock_fields[20]['enigme_solution_delai'] = 1;
+        $mock_fields[20]['enigme_solution_heure'] = '00:00';
+        $mock_fields[10]['date_de_decouverte'] = '2020-01-01';
+        $mock_current_time = strtotime('2020-01-01 12:00:00');
+
+        $this->assertFalse(solution_peut_etre_affichee(20));
+    }
+
+    public function test_solution_visible_after_delay()
+    {
+        global $mock_posts, $mock_fields, $mock_current_time;
+        $mock_posts[10] = ['post_type' => 'chasse'];
+        $mock_posts[20] = ['post_type' => 'enigme'];
+        $mock_fields[20]['enigme_chasse_associee'] = 10;
+        $mock_fields[10]['statut_chasse'] = 'Terminée';
+        $mock_fields[20]['enigme_solution_mode'] = 'delai_fin_chasse';
+        $mock_fields[20]['enigme_solution_delai'] = 1;
+        $mock_fields[20]['enigme_solution_heure'] = '00:00';
+        $mock_fields[10]['date_de_decouverte'] = '2020-01-01';
+        $mock_current_time = strtotime('2020-01-03 12:00:00');
+
+        $this->assertTrue(solution_peut_etre_affichee(20));
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -15,6 +15,10 @@ if (!function_exists('add_rewrite_rule')) {
     function add_rewrite_rule(...$args) {}
 }
 
+$mock_posts = [];
+$mock_fields = [];
+$mock_current_time = null;
+
 // Minimal WP user functions for tests
 $mock_users = [];
 $current_user_id = 0;
@@ -37,5 +41,40 @@ if (!function_exists('get_user_by')) {
     }
 }
 
+if (!function_exists('get_post_type')) {
+    function get_post_type($post_id) {
+        global $mock_posts;
+        return $mock_posts[$post_id]['post_type'] ?? null;
+    }
+}
+
+if (!function_exists('get_field')) {
+    function get_field($key, $post_id = 0) {
+        global $mock_fields;
+        return $mock_fields[$post_id][$key] ?? null;
+    }
+}
+
+if (!function_exists('recuperer_id_chasse_associee')) {
+    function recuperer_id_chasse_associee($post_id) {
+        $champ = get_field('enigme_chasse_associee', $post_id);
+        if (is_array($champ)) {
+            return reset($champ);
+        }
+        return $champ;
+    }
+}
+
+if (!function_exists('current_time')) {
+    function current_time($type) {
+        global $mock_current_time;
+        if ($type === 'timestamp') {
+            return $mock_current_time ?? time();
+        }
+        return '';
+    }
+}
+
 require_once __DIR__ . '/../inc/constants.php';
 require_once __DIR__ . '/../inc/access-functions.php';
+require_once __DIR__ . '/../inc/chasse-functions.php';


### PR DESCRIPTION
## Summary
- implement `solution_peut_etre_affichee()` in `chasse-functions.php`
- replace placeholder logic in partial with the new helper
- extend test bootstrap with minimal WP stubs
- add tests for solution visibility

## Testing
- `vendor/bin/phpunit tests` *(fails: No such file or directory)*
- `phpunit tests` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ad097d3cc8332a39573fbd9995edc