### PR TITLE
Refactor script enqueue logic

### DIFF
--- a/inc/edition/edition-chasse.php
+++ b/inc/edition/edition-chasse.php
@@ -29,24 +29,8 @@ function enqueue_script_chasse_edit()
     return;
   }
 
-  $theme_uri = get_stylesheet_directory_uri();
-  $theme_dir = get_stylesheet_directory();
-
-  // Enfile les scripts partagés (helpers, ui, etc.)
-  enqueue_core_edit_scripts();
-
-  // Script spécifique à la chasse
-  $path = '/assets/js/chasse-edit.js';
-  $file = $theme_dir . $path;
-  $version = file_exists($file) ? filemtime($file) : null;
-
-  wp_enqueue_script(
-    'chasse-edit',
-    $theme_uri . $path,
-    ['helpers', 'ajax', 'ui', 'champ-init'],
-    $version,
-    true
-  );
+  // Enfile les scripts nécessaires
+  enqueue_core_edit_scripts(['chasse-edit']);
 
   // Injecte les valeurs par défaut pour JS
   wp_localize_script('champ-init', 'CHP_CHASSE_DEFAUT', [

--- a/inc/edition/edition-enigme.php
+++ b/inc/edition/edition-enigme.php
@@ -31,35 +31,8 @@ function enqueue_script_enigme_edit()
   $enigme_id = get_the_ID();
   if (!utilisateur_peut_modifier_post($enigme_id)) return;
 
-  $theme_uri = get_stylesheet_directory_uri();
-  $theme_dir = get_stylesheet_directory();
-
-  // 📦 Modules JS partagés
-  enqueue_core_edit_scripts();
-
-  // 📤 Header organisateur
-  $path_org = '/assets/js/organisateur-edit.js';
-  $version_org = file_exists($theme_dir . $path_org) ? filemtime($theme_dir . $path_org) : null;
-
-  wp_enqueue_script(
-    'organisateur-edit',
-    $theme_uri . $path_org,
-    ['champ-init', 'helpers', 'ajax', 'ui'],
-    $version_org,
-    true
-  );
-
-  // 📤 Panneau énigme
-  $path_enigme = '/assets/js/enigme-edit.js';
-  $version_enigme = file_exists($theme_dir . $path_enigme) ? filemtime($theme_dir . $path_enigme) : null;
-
-  wp_enqueue_script(
-    'enigme-edit',
-    $theme_uri . $path_enigme,
-    ['champ-init', 'helpers', 'ajax', 'ui'],
-    $version_enigme,
-    true
-  );
+  // 📦 Modules JS partagés + scripts spécifiques
+  enqueue_core_edit_scripts(['organisateur-edit', 'enigme-edit']);
 
   // Localisation JS si besoin (ex : valeurs par défaut)
   wp_localize_script('champ-init', 'CHP_ENIGME_DEFAUT', [

--- a/inc/edition/edition-organisateur.php
+++ b/inc/edition/edition-organisateur.php
@@ -130,23 +130,8 @@ function enqueue_script_organisateur_edit()
   }
 
   if ($organisateur_id && utilisateur_peut_modifier_post($organisateur_id)) {
-    $theme_uri = get_stylesheet_directory_uri();
-    $theme_dir = get_stylesheet_directory();
-
-    // 📦 Modules JS partagés
-    enqueue_core_edit_scripts();
-
-    // 📤 Script organisateur
-    $path = '/assets/js/organisateur-edit.js';
-    $version = file_exists($theme_dir . $path) ? filemtime($theme_dir . $path) : null;
-
-    wp_enqueue_script(
-      'organisateur-edit',
-      $theme_uri . $path,
-      ['champ-init', 'helpers', 'ajax', 'ui'],
-      $version,
-      true
-    );
+    // 📦 Modules JS partagés + script organisateur
+    enqueue_core_edit_scripts(['organisateur-edit']);
 
     // ✅ Injection JavaScript APRÈS le enqueue (très important)
     $author_id = (int) get_post_field('post_author', $organisateur_id);


### PR DESCRIPTION
## Summary
- centralize enqueue logic for editing scripts
- inject extra script handles per CPT

## Testing
- `php -l inc/edition/edition-core.php`
- `php -l inc/edition/edition-chasse.php`
- `php -l inc/edition/edition-enigme.php`
- `php -l inc/edition/edition-organisateur.php`


------
https://chatgpt.com/codex/tasks/task_e_685ad38c5f6c83329e8a16fa146d1e32