### PR TITLE
Add headings above content loops

### DIFF
--- a/single-chasse.php
+++ b/single-chasse.php
@@ -138,6 +138,8 @@ $validation_envoyee = !empty($_GET['validation_demandee']);
           </div>
         </header>
 
+        <h2>Énigmes</h2>
+        <div class="separateur-2"></div>
         <div class="chasse-enigmes-liste">
           <?php
           get_template_part('template-parts/enigme/chasse-partial-boucle-enigmes', null, [

--- a/template-parts/organisateur/organisateur-partial-boucle-chasses.php
+++ b/template-parts/organisateur/organisateur-partial-boucle-chasses.php
@@ -17,6 +17,8 @@ $posts   = array_values(array_filter($posts, function ($post) use ($user_id) {
 
 ?>
 
+<h2>Ses chasses</h2>
+<div class="separateur-2"></div>
 <div class="grille-liste">
   <?php foreach ($posts as $post) : ?>
     <?php


### PR DESCRIPTION
## Summary
- show a section title before listing organizer hunts
- mark the start of puzzle lists on hunt pages

## Testing
- `phpunit -c tests/phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_685ade2e871c833284c7ead037bf1212