### PR TITLE
Add close button to organizer info panel

### DIFF
--- a/assets/css/organisateurs.css
+++ b/assets/css/organisateurs.css
@@ -434,6 +434,7 @@ body:not(.edition-active) #presentation .champ-liens.champ-vide {
 
 section#presentation {
     margin-top:1rem;
+    position: relative;
 }
 section#presentation.masque {
     margin: 0;
@@ -452,6 +453,12 @@ section#presentation .titre-presentation {
   font-size: 1.8rem;
   margin-bottom: 1.5rem;
   position: relative;
+}
+
+section#presentation .presentation-fermer {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
 }
 
 

--- a/assets/js/header-organisateur-ui.js
+++ b/assets/js/header-organisateur-ui.js
@@ -19,6 +19,12 @@ document.addEventListener('DOMContentLoaded', () => {
     document.getElementById('presentation')?.classList.remove('masque');
   }
 
+  // ❌ Bouton de fermeture de la présentation
+  document.querySelector('#presentation .presentation-fermer')?.addEventListener('click', () => {
+    document.getElementById('presentation')?.classList.add('masque');
+    document.activeElement?.blur();
+  });
+
   // ✅ Panneau latéral ACF – ouverture (bouton déclencheur)
   document.addEventListener('click', (e) => {
     const btn = e.target.closest('.ouvrir-panneau-description');

--- a/template-parts/organisateur/organisateur-partial-presentation.php
+++ b/template-parts/organisateur/organisateur-partial-presentation.php
@@ -30,6 +30,7 @@ if (!empty($liens_publics) && is_array($liens_publics)) {
 ?>
 
 <section id="presentation" class="bloc-presentation-organisateur bloc-toggle masque bloc-discret">
+    <button type="button" class="panneau-fermer presentation-fermer" aria-label="Fermer les informations">✖</button>
     <!-- Liens publics -->
     <?php $champ_vide_liens = count($liens_actifs) === 0;    ?>
     <?php $classe_liens = count($liens_actifs) >= 3 ? 'liens-compacts' : ''; ?>


### PR DESCRIPTION
## Summary
- add close button to organizer info section
- style the button within the presentation panel
- handle closing interaction via JavaScript

## Testing
- `composer install`
- `vendor/bin/phpunit --configuration tests/phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_685adf92c160833283cabf2c4b464dae