### PR TITLE
Add Composer autoload setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,15 @@ vendor/bin/phpunit --configuration tests/phpunit.xml
 ```
 
 More details about the theme development workflow are available in the [docs/](docs/) directory.
+
+## Autoloading
+
+The `inc/` directory is registered with Composer so all helper files are loaded
+automatically. After modifying `composer.json` run:
+
+```bash
+composer dump-autoload
+```
+
+The theme loads `vendor/autoload.php` in `functions.php`, so no manual
+`require` statements are needed for files inside `inc/`.

--- a/composer.json
+++ b/composer.json
@@ -1,9 +1,29 @@
 {
     "autoload": {
         "psr-4": {
-            "Chasses\\Enigme\\": "inc/enigme/"
+            "Chasses\\": "inc/"
         },
         "files": [
+            "inc/constants.php",
+            "inc/utils.php",
+            "inc/shortcodes-init.php",
+            "inc/enigme-functions.php",
+            "inc/user-functions.php",
+            "inc/chasse-functions.php",
+            "inc/gamify-functions.php",
+            "inc/utils/titres.php",
+            "inc/statut-functions.php",
+            "inc/admin-functions.php",
+            "inc/organisateur-functions.php",
+            "inc/access-functions.php",
+            "inc/relations-functions.php",
+            "inc/layout-functions.php",
+            "inc/utils/liens.php",
+            "inc/edition/edition-core.php",
+            "inc/edition/edition-organisateur.php",
+            "inc/edition/edition-chasse.php",
+            "inc/edition/edition-enigme.php",
+            "inc/edition/edition-securite.php",
             "inc/enigme/Cta.php",
             "inc/enigme/ManualResponse.php",
             "inc/enigme/Tentatives.php"

--- a/functions.php
+++ b/functions.php
@@ -12,10 +12,6 @@ defined( 'ABSPATH' ) || exit;
 $autoload = __DIR__ . '/vendor/autoload.php';
 if (file_exists($autoload)) {
     require_once $autoload;
-} else {
-    require_once __DIR__ . '/inc/enigme/Cta.php';
-    require_once __DIR__ . '/inc/enigme/ManualResponse.php';
-    require_once __DIR__ . '/inc/enigme/Tentatives.php';
 }
 
 /**
@@ -60,37 +56,8 @@ add_action('wp_enqueue_scripts', function () {
 
 
 // ----------------------------------------------------------
-// 📂 Chargement des fichiers fonctionnels organisés
+// 📂 Les fichiers du dossier inc/ sont chargés via Composer
 // ----------------------------------------------------------
-
-$inc_path = get_stylesheet_directory() . '/inc/';
-
-require_once $inc_path . 'constants.php';
-require_once $inc_path . 'utils.php';
-
-require_once $inc_path . 'shortcodes-init.php';
-require_once $inc_path . 'enigme-functions.php';
-require_once $inc_path . 'user-functions.php';
-require_once $inc_path . 'chasse-functions.php';
-require_once $inc_path . 'gamify-functions.php';
-require_once $inc_path . 'utils/titres.php';
-require_once $inc_path . 'statut-functions.php';
-require_once $inc_path . 'admin-functions.php';
-require_once $inc_path . 'organisateur-functions.php';
-//require_once $inc_path . 'stat-functions.php';
-require_once $inc_path . 'access-functions.php';
-require_once $inc_path . 'relations-functions.php';
-require_once $inc_path . 'layout-functions.php';
-require_once $inc_path . 'utils/liens.php';
-
-require_once $inc_path . 'edition/edition-core.php';
-require_once $inc_path . 'edition/edition-organisateur.php';
-require_once $inc_path . 'edition/edition-chasse.php';
-require_once $inc_path . 'edition/edition-enigme.php';
-require_once $inc_path . 'edition/edition-securite.php';
-
-
-
 /**
  * Injecte automatiquement `acf_form_head()` pour les fiches chasse.
  *


### PR DESCRIPTION
## Summary
- configure Composer to autoload all `inc/` helpers
- drop manual includes in `functions.php`
- document the autoload mechanism in README

## Testing
- `composer install`
- `vendor/bin/phpunit --configuration tests/phpunit.xml` *(fails: no output)*

------
https://chatgpt.com/codex/tasks/task_e_685ae68c695c8332b6ea9cc872e71c14