### PR TITLE
Add WP_Mock and tests for namespaced components

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,7 @@
         ]
     },
     "require-dev": {
-        "phpunit/phpunit": "^9"
+        "phpunit/phpunit": "^9",
+        "10up/wp_mock": "^1.0"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,9 +4,111 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "eaf427e91c04d06abdb542687ebc4d5d",
+    "content-hash": "34b742fbfb0678952388f9cb7a255903",
     "packages": [],
     "packages-dev": [
+        {
+            "name": "10up/wp_mock",
+            "version": "1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/10up/wp_mock.git",
+                "reference": "f25b5895ed31bf5e7036fe0c666664364ae011c2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/10up/wp_mock/zipball/f25b5895ed31bf5e7036fe0c666664364ae011c2",
+                "reference": "f25b5895ed31bf5e7036fe0c666664364ae011c2",
+                "shasum": ""
+            },
+            "require": {
+                "antecedent/patchwork": "^2.1",
+                "mockery/mockery": "^1.6",
+                "php": ">=7.4 < 9",
+                "phpunit/phpunit": "^9.6"
+            },
+            "require-dev": {
+                "behat/behat": "^v3.11.0",
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.7",
+                "friendsofphp/php-cs-fixer": "^3.4",
+                "php-coveralls/php-coveralls": "^v2.7",
+                "php-stubs/wordpress-globals": "^0.2",
+                "php-stubs/wordpress-stubs": "^6.3",
+                "phpcompatibility/php-compatibility": "^9.3",
+                "phpstan/phpstan": "^1.10",
+                "phpstan/phpstan-mockery": "^1.1",
+                "phpstan/phpstan-phpunit": "^1.3",
+                "sebastian/comparator": "^4.0.8",
+                "sempro/phpunit-pretty-print": "^1.4"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "WP_Mock\\": "./php/WP_Mock"
+                },
+                "classmap": [
+                    "php/WP_Mock.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "A mocking library to take the pain out of unit testing for WordPress",
+            "support": {
+                "issues": "https://github.com/10up/wp_mock/issues",
+                "source": "https://github.com/10up/wp_mock/tree/1.1.0"
+            },
+            "time": "2025-03-12T00:36:13+00:00"
+        },
+        {
+            "name": "antecedent/patchwork",
+            "version": "2.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/antecedent/patchwork.git",
+                "reference": "1bf183a3e1bd094f231a2128b9ecc5363c269245"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/antecedent/patchwork/zipball/1bf183a3e1bd094f231a2128b9ecc5363c269245",
+                "reference": "1bf183a3e1bd094f231a2128b9ecc5363c269245",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": ">=4"
+            },
+            "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ignas Rudaitis",
+                    "email": "ignas.rudaitis@gmail.com"
+                }
+            ],
+            "description": "Method redefinition (monkey-patching) functionality for PHP.",
+            "homepage": "https://antecedent.github.io/patchwork/",
+            "keywords": [
+                "aop",
+                "aspect",
+                "interception",
+                "monkeypatching",
+                "redefinition",
+                "runkit",
+                "testing"
+            ],
+            "support": {
+                "issues": "https://github.com/antecedent/patchwork/issues",
+                "source": "https://github.com/antecedent/patchwork/tree/2.2.1"
+            },
+            "time": "2024-12-11T10:19:54+00:00"
+        },
         {
             "name": "doctrine/instantiator",
             "version": "2.0.0",
@@ -76,6 +178,140 @@
                 }
             ],
             "time": "2022-12-30T00:23:10+00:00"
+        },
+        {
+            "name": "hamcrest/hamcrest-php",
+            "version": "v2.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/hamcrest/hamcrest-php.git",
+                "reference": "f8b1c0173b22fa6ec77a81fe63e5b01eba7e6487"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/hamcrest/hamcrest-php/zipball/f8b1c0173b22fa6ec77a81fe63e5b01eba7e6487",
+                "reference": "f8b1c0173b22fa6ec77a81fe63e5b01eba7e6487",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4|^8.0"
+            },
+            "replace": {
+                "cordoval/hamcrest-php": "*",
+                "davedevelopment/hamcrest-php": "*",
+                "kodova/hamcrest-php": "*"
+            },
+            "require-dev": {
+                "phpunit/php-file-iterator": "^1.4 || ^2.0 || ^3.0",
+                "phpunit/phpunit": "^4.8.36 || ^5.7 || ^6.5 || ^7.0 || ^8.0 || ^9.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "hamcrest"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "This is the PHP port of Hamcrest Matchers",
+            "keywords": [
+                "test"
+            ],
+            "support": {
+                "issues": "https://github.com/hamcrest/hamcrest-php/issues",
+                "source": "https://github.com/hamcrest/hamcrest-php/tree/v2.1.1"
+            },
+            "time": "2025-04-30T06:54:44+00:00"
+        },
+        {
+            "name": "mockery/mockery",
+            "version": "1.6.12",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/mockery/mockery.git",
+                "reference": "1f4efdd7d3beafe9807b08156dfcb176d18f1699"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/mockery/mockery/zipball/1f4efdd7d3beafe9807b08156dfcb176d18f1699",
+                "reference": "1f4efdd7d3beafe9807b08156dfcb176d18f1699",
+                "shasum": ""
+            },
+            "require": {
+                "hamcrest/hamcrest-php": "^2.0.1",
+                "lib-pcre": ">=7.0",
+                "php": ">=7.3"
+            },
+            "conflict": {
+                "phpunit/phpunit": "<8.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^8.5 || ^9.6.17",
+                "symplify/easy-coding-standard": "^12.1.14"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "library/helpers.php",
+                    "library/Mockery.php"
+                ],
+                "psr-4": {
+                    "Mockery\\": "library/Mockery"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Pádraic Brady",
+                    "email": "padraic.brady@gmail.com",
+                    "homepage": "https://github.com/padraic",
+                    "role": "Author"
+                },
+                {
+                    "name": "Dave Marshall",
+                    "email": "dave.marshall@atstsolutions.co.uk",
+                    "homepage": "https://davedevelopment.co.uk",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Nathanael Esayeas",
+                    "email": "nathanael.esayeas@protonmail.com",
+                    "homepage": "https://github.com/ghostwriter",
+                    "role": "Lead Developer"
+                }
+            ],
+            "description": "Mockery is a simple yet flexible PHP mock object framework",
+            "homepage": "https://github.com/mockery/mockery",
+            "keywords": [
+                "BDD",
+                "TDD",
+                "library",
+                "mock",
+                "mock objects",
+                "mockery",
+                "stub",
+                "test",
+                "test double",
+                "testing"
+            ],
+            "support": {
+                "docs": "https://docs.mockery.io/",
+                "issues": "https://github.com/mockery/mockery/issues",
+                "rss": "https://github.com/mockery/mockery/releases.atom",
+                "security": "https://github.com/mockery/mockery/security/advisories",
+                "source": "https://github.com/mockery/mockery"
+            },
+            "time": "2024-05-16T03:13:13+00:00"
         },
         {
             "name": "myclabs/deep-copy",

--- a/tests/AccessFunctionsTest.php
+++ b/tests/AccessFunctionsTest.php
@@ -1,5 +1,5 @@
 <?php
-use PHPUnit\Framework\TestCase;
+use WP_Mock\Tools\TestCase;
 
 require_once __DIR__ . '/bootstrap.php';
 
@@ -7,11 +7,18 @@ class AccessFunctionsTest extends TestCase
 {
     protected function setUp(): void
     {
+        parent::setUp();
         global $mock_users, $mock_posts, $mock_fields, $current_user_id;
         $mock_users = [];
         $mock_posts = [];
         $mock_fields = [];
         $current_user_id = 0;
+    }
+
+    protected function tearDown(): void
+    {
+        \WP_Mock::tearDown();
+        parent::tearDown();
     }
 
     public function test_est_organisateur_role_principal()

--- a/tests/EnigmeNamespacedTest.php
+++ b/tests/EnigmeNamespacedTest.php
@@ -1,0 +1,54 @@
+<?php
+use WP_Mock\Tools\TestCase;
+use function Chasses\Enigme\enigme_get_liste_prerequis_possibles;
+use function Chasses\Enigme\utilisateur_peut_repondre_manuelle;
+
+require_once __DIR__ . '/bootstrap.php';
+
+class EnigmeNamespacedTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        \WP_Mock::tearDown();
+        parent::tearDown();
+    }
+
+    public function test_enigme_get_liste_prerequis_possibles_filters_list()
+    {
+        \WP_Mock::userFunction('get_field', [
+            'times'  => 3,
+            'return_in_order' => [10, 'code', 'aucune'],
+        ]);
+        \WP_Mock::userFunction('recuperer_enigmes_associees', [
+            'times' => 1,
+            'return' => [1, 2, 3],
+        ]);
+        \WP_Mock::userFunction('get_the_title', [
+            'times' => 2,
+            'return_in_order' => ['Premiere enigme', 'Deuxieme enigme'],
+        ]);
+
+        $result = enigme_get_liste_prerequis_possibles(2);
+        $this->assertSame([1 => 'Premiere enigme'], $result);
+    }
+
+    public function test_utilisateur_peut_repondre_manuelle_true_when_authorized()
+    {
+        \WP_Mock::userFunction('enigme_get_statut_utilisateur', [
+            'times' => 1,
+            'args' => [5, 1],
+            'return' => 'en_cours',
+        ]);
+        $this->assertTrue(utilisateur_peut_repondre_manuelle(1, 5));
+    }
+
+    public function test_utilisateur_peut_repondre_manuelle_false_when_not_authorized()
+    {
+        \WP_Mock::userFunction('enigme_get_statut_utilisateur', [
+            'times' => 1,
+            'args' => [5, 2],
+            'return' => 'terminee',
+        ]);
+        $this->assertFalse(utilisateur_peut_repondre_manuelle(2, 5));
+    }
+}

--- a/tests/RoleSwitchTest.php
+++ b/tests/RoleSwitchTest.php
@@ -1,5 +1,5 @@
 <?php
-use PHPUnit\Framework\TestCase;
+use WP_Mock\Tools\TestCase;
 
 require_once __DIR__ . '/bootstrap.php';
 
@@ -7,9 +7,16 @@ class RoleSwitchTest extends TestCase
 {
     protected function setUp(): void
     {
+        parent::setUp();
         global $mock_users, $current_user_id;
         $mock_users = [];
         $current_user_id = 0;
+    }
+
+    protected function tearDown(): void
+    {
+        \WP_Mock::tearDown();
+        parent::tearDown();
     }
 
     public function test_ajouter_role_organisateur_creation_adds_role()

--- a/tests/SolutionVisibilityTest.php
+++ b/tests/SolutionVisibilityTest.php
@@ -1,5 +1,5 @@
 <?php
-use PHPUnit\Framework\TestCase;
+use WP_Mock\Tools\TestCase;
 
 require_once __DIR__ . '/bootstrap.php';
 
@@ -7,10 +7,17 @@ class SolutionVisibilityTest extends TestCase
 {
     protected function setUp(): void
     {
+        parent::setUp();
         global $mock_posts, $mock_fields, $mock_current_time;
         $mock_posts = [];
         $mock_fields = [];
         $mock_current_time = null;
+    }
+
+    protected function tearDown(): void
+    {
+        \WP_Mock::tearDown();
+        parent::tearDown();
     }
 
     public function test_solution_hidden_if_chasse_not_terminee()

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -4,16 +4,8 @@ if (!defined('ABSPATH')) {
     define('ABSPATH', __DIR__ . '/..');
 }
 
-// Dummy WordPress hook functions
-if (!function_exists('add_action')) {
-    function add_action(...$args) {}
-}
-if (!function_exists('add_filter')) {
-    function add_filter(...$args) {}
-}
-if (!function_exists('add_rewrite_rule')) {
-    function add_rewrite_rule(...$args) {}
-}
+require_once __DIR__ . '/../vendor/autoload.php';
+\WP_Mock::bootstrap();
 
 $mock_posts = [];
 $mock_fields = [];

--- a/tests/phpunit-autoload.php
+++ b/tests/phpunit-autoload.php
@@ -1,0 +1,5 @@
+<?php
+if (!defined('ABSPATH')) {
+    define('ABSPATH', dirname(__DIR__));
+}
+require __DIR__ . '/../vendor/autoload.php';


### PR DESCRIPTION
## Summary
- require 10up/wp_mock for dev
- bootstrap WP_Mock for tests
- use WP_Mock test case in unit tests
- add tests for namespaced Enigme helper functions
- helper autoloader for phpunit

## Testing
- `php vendor/phpunit/phpunit/phpunit -c tests/phpunit.xml --testdox` *(fails: no output)*

------
https://chatgpt.com/codex/tasks/task_e_685aea2eb5f08332894ae09a71af8086