### PR TITLE
Fix organizer panel initialization on puzzle page

### DIFF
--- a/assets/js/enigme-edit.js
+++ b/assets/js/enigme-edit.js
@@ -7,7 +7,7 @@ let panneauEdition;
 
 
 
-document.addEventListener('DOMContentLoaded', () => {
+function initEnigmeEdit() {
   boutonToggle = document.getElementById('toggle-mode-edition-enigme');
   panneauEdition = document.querySelector('.edition-panel-enigme');
 
@@ -453,6 +453,12 @@ function initChampNbTentatives() {
 
   // 🔄 Fonction exportée globalement
   window.mettreAJourMessageTentatives = mettreAJourAideTentatives;
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', initEnigmeEdit);
+} else {
+  initEnigmeEdit();
 }
 
 

--- a/assets/js/header-organisateur-ui.js
+++ b/assets/js/header-organisateur-ui.js
@@ -6,7 +6,7 @@
 // - Panneau latéral ACF (présentation)
 // ========================================
 
-document.addEventListener('DOMContentLoaded', () => {
+function initHeaderOrganisateurUI() {
 
   // ✅ Icône info : affichage/masquage de la description
   document.querySelector('.bouton-toggle-description')?.addEventListener('click', () => {
@@ -42,4 +42,10 @@ document.addEventListener('DOMContentLoaded', () => {
       document.activeElement?.blur();
     }
   });
-});
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', initHeaderOrganisateurUI);
+} else {
+  initHeaderOrganisateurUI();
+}

--- a/assets/js/organisateur-edit.js
+++ b/assets/js/organisateur-edit.js
@@ -1,7 +1,7 @@
 var DEBUG = window.DEBUG || false;
 DEBUG && console.log('✅ organisateur-edit.js chargé');
 
-document.addEventListener('DOMContentLoaded', () => {
+function initOrganisateurEdit() {
 
   // 🟢 Champs inline
   document.querySelectorAll('.champ-organisateur[data-champ]').forEach((bloc) => {
@@ -151,7 +151,13 @@ document.addEventListener('DOMContentLoaded', () => {
     window.mettreAJourResumeInfos();
   }
 
-});
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', initOrganisateurEdit);
+} else {
+  initOrganisateurEdit();
+}
 
 
 function initLiensOrganisateur(bloc) {

--- a/template-parts/enigme/enigme-edition-main.php
+++ b/template-parts/enigme/enigme-edition-main.php
@@ -7,6 +7,8 @@
 
 defined('ABSPATH') || exit;
 
+use function Chasses\Enigme\enigme_get_liste_prerequis_possibles;
+
 $enigme_id = $args['enigme_id'] ?? null;
 if (!$enigme_id || get_post_type($enigme_id) !== 'enigme') {
   return;


### PR DESCRIPTION
## Summary
- initialize organizer edit scripts based on document readiness
- ensure header organizer UI loads even if script runs after DOMContentLoaded

## Testing
- `composer install` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685af0723c648332823ed5c83f14bbe6