### PR TITLE
Compute edition flag once

### DIFF
--- a/single-enigme.php
+++ b/single-enigme.php
@@ -57,6 +57,9 @@ if (is_singular('enigme')) {
   forcer_relation_enigme_dans_chasse_si_absente($enigme_id);
 }
 
+// 🔹 Autorisations d'édition
+$peut_modifier = utilisateur_peut_voir_panneau($enigme_id);
+
 ?>
 <?php get_header(); ?>
 
@@ -73,7 +76,7 @@ if (is_singular('enigme')) {
       <?php if (enigme_est_visible_pour($user_id, $enigme_id)) : ?>
         <section class="enigme-wrapper">
           <!-- 🔧 Bouton pour ouvrir le panneau d’édition -->
-          <?php if ($edition_active) : ?>
+          <?php if ($peut_modifier) : ?>
             <div class="header-actions-droite">
               <button id="toggle-mode-edition-enigme" type="button"
                       class="bouton-edition-toggle"
@@ -91,8 +94,9 @@ if (is_singular('enigme')) {
 
       <!-- 🛠 Panneau principal d’édition -->
       <?php get_template_part('template-parts/enigme/enigme-edition-main', null, [
-        'enigme_id' => $enigme_id,
-        'user_id'   => $user_id,
+        'enigme_id'     => $enigme_id,
+        'user_id'       => $user_id,
+        'peut_modifier' => $peut_modifier,
       ]); ?>
 
       <?php if ($edition_active) : ?>

--- a/template-parts/enigme/enigme-edition-main.php
+++ b/template-parts/enigme/enigme-edition-main.php
@@ -17,7 +17,7 @@ if (!$enigme_id || get_post_type($enigme_id) !== 'enigme') {
   return;
 }
 
-$peut_modifier = utilisateur_peut_voir_panneau($enigme_id);
+$peut_modifier = $args['peut_modifier'] ?? false;
 $peut_editer   = utilisateur_peut_editer_champs($enigme_id);
 $peut_editer_titre = champ_est_editable('post_title', $enigme_id);
 


### PR DESCRIPTION
## Summary
- check puzzle panel permissions in `single-enigme.php`
- show edition toggle only when `$peut_modifier` is true
- forward permission to `enigme-edition-main.php`

## Testing
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b093123148332ba11e6f9810f9f50