### PR TITLE
Fix duplicate DOMContentLoaded in enigme-edit.js

### DIFF
--- a/assets/js/enigme-edit.js
+++ b/assets/js/enigme-edit.js
@@ -472,27 +472,6 @@ if (document.readyState === 'loading') {
   initEnigmeEdit();
 }
 
-if (document.readyState === 'loading') {
-  DEBUG && console.log('[enigme-edit] waiting DOMContentLoaded');
-  document.addEventListener('DOMContentLoaded', () => {
-    DEBUG && console.log('[enigme-edit] DOMContentLoaded');
-    initEnigmeEdit();
-  });
-} else {
-  initEnigmeEdit();
-}
-
-if (document.readyState === 'loading') {
-  DEBUG && console.log('[enigme-edit] waiting DOMContentLoaded');
-  document.addEventListener('DOMContentLoaded', () => {
-    DEBUG && console.log('[enigme-edit] DOMContentLoaded');
-    initEnigmeEdit();
-  });
-
-} else {
-  initEnigmeEdit();
-}
-
 
 
 // ================================


### PR DESCRIPTION
## Summary
- remove duplicate DOMContentLoaded checks in `enigme-edit.js`
- keep a single `initEnigmeEdit()` invocation

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_685b0b9806788332997b87c6792038cc