### PR TITLE
Add immediat mapping for access condition radios

### DIFF
--- a/assets/js/enigme-edit.js
+++ b/assets/js/enigme-edit.js
@@ -224,6 +224,7 @@ function initEnigmeEdit() {
   initChampSolution();
   initSolutionInline();
   initChampConditionnel('acf[enigme_acces_condition]', {
+    'immediat': [],
     'date_programmee': ['#champ-enigme-date'],
     'pre_requis': ['#champ-enigme-pre-requis']
   });


### PR DESCRIPTION
## Summary
- ensure each `enigme_acces_condition` radio option has a mapping

## Testing
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b55663844833294dd180c91dc09a0