### PR TITLE
Improve JSON fetch handling

### DIFF
--- a/assets/js/core/champ-init.js
+++ b/assets/js/core/champ-init.js
@@ -24,7 +24,19 @@ function modifierChampSimple(champ, valeur, postId, cpt = 'enigme') {
       post_id: postId
     })
   })
-    .then(r => r.json())
+    .then(r => {
+      const contentType = r.headers.get('Content-Type') || '';
+      if (contentType.includes('application/json')) {
+        return r.json().catch(err => {
+          console.error('❌ Erreur parsing JSON :', err);
+          return { success: false };
+        });
+      }
+      return r.text().then(text => {
+        console.warn('⚠️ Réponse inattendue :', contentType, text);
+        return { success: false };
+      });
+    })
     .then(res => {
       if (res.success) {
         DEBUG && console.log(`✅ Champ ${champ} enregistré`);


### PR DESCRIPTION
## Summary
- check the fetch `Content-Type` in `modifierChampSimple`
- log a warning if the response isn't JSON
- catch JSON parsing errors

## Testing
- `composer install` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b560a67988332a60ffa8d7450a285