### PR TITLE
Add init guard for puzzle editing script

### DIFF
--- a/assets/js/enigme-edit.js
+++ b/assets/js/enigme-edit.js
@@ -5,9 +5,14 @@ DEBUG && console.log('✅ enigme-edit.js chargé (readyState =', document.readyS
 
 let boutonToggle;
 let panneauEdition;
+let enigmeEditInitialized = false;
 
 
 function initEnigmeEdit() {
+  if (enigmeEditInitialized) {
+    DEBUG && console.log('[enigme-edit] already initialized');
+    return;
+  }
   DEBUG && console.log('[enigme-edit] initEnigmeEdit');
   boutonToggle = document.getElementById('toggle-mode-edition-enigme');
   panneauEdition = document.querySelector('.edition-panel-enigme');
@@ -461,6 +466,7 @@ function initChampNbTentatives() {
 
   // 🔄 Fonction exportée globalement
   window.mettreAJourMessageTentatives = mettreAJourAideTentatives;
+  enigmeEditInitialized = true;
 }
 
 if (document.readyState === 'loading') {


### PR DESCRIPTION
## Summary
- initialize global flag `enigmeEditInitialized`
- guard against running `initEnigmeEdit` multiple times
- mark initialization complete after setup

## Testing
- `composer test` *(fails: phpunit requires extensions not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685b5e9c627083328b33d24a96f693c5