### PR TITLE
Fix parse error in visuels module

### DIFF
--- a/inc/enigme/visuels.php
+++ b/inc/enigme/visuels.php
@@ -262,3 +262,11 @@ defined('ABSPATH') || exit;
                 'jpg', 'jpeg' => 'image/jpeg',
                 'png'         => 'image/png',
                 'gif'         => 'image/gif',
+                'webp'        => 'image/webp',
+                default       => 'application/octet-stream',
+            };
+            return ['path' => $path, 'mime' => $mime];
+        }
+
+        return null;
+    }


### PR DESCRIPTION
## Summary
- fix missing lines at end of `visuels.php`

## Testing
- `php --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b6c1939708332ae63e0f5462a6eeb