### PR TITLE
Fix HTML showing in organizer snippet

### DIFF
--- a/inc/layout-functions.php
+++ b/inc/layout-functions.php
@@ -301,9 +301,9 @@ function filtrer_content_sans_titre($content) {
  * @return string HTML généré avec le texte tronqué et le toggle.
  */
 function limiter_texte_avec_toggle($texte, $limite = 200, $label_plus = 'Lire la suite', $label_moins = 'Réduire') {
-    $texte = trim($texte);
+    $texte = trim(wp_strip_all_tags($texte));
     if (mb_strlen($texte) <= $limite) {
-        return wpautop($texte);
+        return wpautop(esc_html($texte));
     }
 
     $texte_visible = mb_substr($texte, 0, $limite);


### PR DESCRIPTION
## Summary
- sanitize text in `limiter_texte_avec_toggle`

## Testing
- `phpunit -c tests/phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_685b8bf433408332ab3c97e06b79fc48