### PR TITLE
Highlight add hunt card for first-time organisers

### DIFF
--- a/single-organisateur.php
+++ b/single-organisateur.php
@@ -94,6 +94,7 @@ get_header();
                             }));
                             $peut_ajouter = utilisateur_peut_ajouter_chasse($organisateur_id);
                             $has_chasses = !empty($chasses);
+                            $highlight_pulse = !$has_chasses && $is_owner && in_array(ROLE_ORGANISATEUR_CREATION, $roles, true);
 
                             foreach ($chasses as $post) :
                                 $chasse_id = $post->ID;
@@ -109,8 +110,9 @@ get_header();
 
                             <?php if ($peut_ajouter) :
                                 get_template_part('template-parts/chasse/chasse-partial-ajout-chasse', null, [
-                                    'has_chasses' => $has_chasses,
+                                    'has_chasses'    => $has_chasses,
                                     'organisateur_id' => $organisateur_id,
+                                    'highlight_pulse' => $highlight_pulse,
                                 ]);
                             endif; ?>
                         </div>

--- a/template-parts/chasse/chasse-partial-ajout-chasse.php
+++ b/template-parts/chasse/chasse-partial-ajout-chasse.php
@@ -3,6 +3,7 @@ defined('ABSPATH') || exit;
 
 $organisateur_id = $args['organisateur_id'] ?? null;
 $has_chasses = $args['has_chasses'] ?? false;
+$highlight_pulse = $args['highlight_pulse'] ?? false;
 
 
 if (!$organisateur_id || get_post_type($organisateur_id) !== 'organisateur') {
@@ -13,7 +14,7 @@ if (!$organisateur_id || get_post_type($organisateur_id) !== 'organisateur') {
 <a
   href="<?= esc_url(site_url('/creer-chasse/')); ?>"
   id="carte-ajout-chasse"
-  class="carte-chasse carte-ajout-chasse disabled"
+  class="carte-chasse carte-ajout-chasse disabled<?= $highlight_pulse ? ' pulsation' : ''; ?>"
   data-post-id="0">
 
   <div class="carte-chasse-contenu">


### PR DESCRIPTION
## Summary
- pulse the 'add hunt' card when organiser has no hunts yet

## Testing
- `php -l single-organisateur.php`
- `php -l template-parts/chasse/chasse-partial-ajout-chasse.php`
- ❌ `composer install && ./vendor/bin/phpunit -c tests/phpunit.xml` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b8c731d5c8332b358e72e3dacc619