### PR TITLE
Highlight add hunt card for complete organisers

### DIFF
--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -660,7 +660,7 @@ body.single-organisateur .formulaire-contact-wrapper .wpforms-field-label {
 /* EFFET PULSATION */
 @keyframes pulsePromo {
     0% { transform: scale(1); opacity: 1; }
-    50% { transform: scale(1.1); opacity: 0.9; }
+    50% { transform: scale(1.05); opacity: 0.9; }
     100% { transform: scale(1); opacity: 1; }
 }
 

--- a/single-organisateur.php
+++ b/single-organisateur.php
@@ -94,6 +94,8 @@ get_header();
                             }));
                             $peut_ajouter = utilisateur_peut_ajouter_chasse($organisateur_id);
                             $has_chasses = !empty($chasses);
+                            $cache_complet = (bool) get_field('organisateur_cache_complet', $organisateur_id);
+                            $highlight_pulse = !$has_chasses && $is_owner && in_array(ROLE_ORGANISATEUR_CREATION, $roles, true) && $cache_complet;
 
                             foreach ($chasses as $post) :
                                 $chasse_id = $post->ID;
@@ -109,8 +111,9 @@ get_header();
 
                             <?php if ($peut_ajouter) :
                                 get_template_part('template-parts/chasse/chasse-partial-ajout-chasse', null, [
-                                    'has_chasses' => $has_chasses,
+                                    'has_chasses'    => $has_chasses,
                                     'organisateur_id' => $organisateur_id,
+                                    'highlight_pulse' => $highlight_pulse,
                                 ]);
                             endif; ?>
                         </div>

--- a/template-parts/chasse/chasse-partial-ajout-chasse.php
+++ b/template-parts/chasse/chasse-partial-ajout-chasse.php
@@ -3,6 +3,7 @@ defined('ABSPATH') || exit;
 
 $organisateur_id = $args['organisateur_id'] ?? null;
 $has_chasses = $args['has_chasses'] ?? false;
+$highlight_pulse = $args['highlight_pulse'] ?? false;
 
 
 if (!$organisateur_id || get_post_type($organisateur_id) !== 'organisateur') {
@@ -13,7 +14,7 @@ if (!$organisateur_id || get_post_type($organisateur_id) !== 'organisateur') {
 <a
   href="<?= esc_url(site_url('/creer-chasse/')); ?>"
   id="carte-ajout-chasse"
-  class="carte-chasse carte-ajout-chasse disabled"
+  class="carte-chasse carte-ajout-chasse disabled<?= $highlight_pulse ? ' pulsation' : ''; ?>"
   data-post-id="0">
 
   <div class="carte-chasse-contenu">


### PR DESCRIPTION
## Summary
- only pulse the 'add hunt' card if organiser post is complete
- slightly reduce the amplitude of the pulsation animation

## Testing
- `php -l single-organisateur.php` *(fails: command not found)*
- `composer install && ./vendor/bin/phpunit -c tests/phpunit.xml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b8c731d5c8332b358e72e3dacc619