### PR TITLE
Implement dynamic organiser CTA

### DIFF
--- a/templates/page-creer-profil.php
+++ b/templates/page-creer-profil.php
@@ -20,7 +20,7 @@ rediriger_selon_etat_organisateur();
 // 3. Gestion de la demande en cours
 if (isset($_GET['resend'])) {
     renvoyer_email_confirmation_organisateur($current_user_id);
-    wp_redirect(add_query_arg('notice', 'profil_verification', home_url('/mon-compte/')));
+    wp_redirect(add_query_arg('notice', 'profil_verification', home_url('/devenir-organisateur/')));
     exit;
 }
 
@@ -33,5 +33,5 @@ if ($token) {
 
 // 4. Nouvelle demande
 lancer_demande_organisateur($current_user_id);
-wp_redirect(add_query_arg('notice', 'profil_verification', home_url('/mon-compte/')));
+wp_redirect(add_query_arg('notice', 'profil_verification', home_url('/devenir-organisateur/')));
 exit;

--- a/templates/page-devenir-organisateur.php
+++ b/templates/page-devenir-organisateur.php
@@ -38,21 +38,19 @@ if (has_post_thumbnail()) {
 }
 
 get_header(); ?>
+<?php if (isset($_GET['notice']) && $_GET['notice'] === 'profil_verification') : ?>
+<div class="woocommerce-message" role="alert">
+  ✉️ Un email de vérification vous a été envoyé. Veuillez cliquer sur le lien pour confirmer votre demande.
+</div>
+<?php endif; ?>
 <section class="bandeau-hero">
   <div class="hero-overlay" style="background-image: url('<?php echo esc_url($image_url); ?>');">
     <div class="contenu-hero">
       <h1><?php the_title(); ?></h1>
       <p class="sous-titre">Créez, publiez et partagez vos aventures interactives.</p>
-      <?php
-        $cta_url  = '/creer-mon-profil/';
-        $cta_text = 'Créer mon profil';
-        if (is_user_logged_in() && get_user_meta($user_id, 'organisateur_demande_token', true)) {
-          $cta_url  = '/creer-mon-profil/?resend=1';
-          $cta_text = "Renvoyer l'email de confirmation";
-        }
-      ?>
-      <a href="<?php echo esc_url($cta_url); ?>" class="bouton-cta" id="creer-profil-btn" data-event="clic_creer_profil">
-        <?php echo esc_html($cta_text); ?>
+      <?php $cta = get_cta_devenir_organisateur(); ?>
+      <a href="<?php echo $cta['url'] ? esc_url($cta['url']) : '#'; ?>" class="bouton-cta" id="creer-profil-btn" data-event="clic_creer_profil" <?php echo $cta['disabled'] ? 'style="pointer-events:none;opacity:0.6"' : ''; ?>>
+        <?php echo esc_html($cta['label']); ?>
       </a>
     </div>
   </div>
@@ -78,7 +76,11 @@ get_header(); ?>
       // Ajout de la section "cta-final"
       $cta_final_post = get_page_by_path('cta-final-devenir-organisateur', OBJECT, 'section_editoriale');
       if ($cta_final_post) {
-         echo apply_filters('the_content', $cta_final_post->post_content);
+         $content = apply_filters('the_content', $cta_final_post->post_content);
+         $cta     = get_cta_devenir_organisateur();
+         $content = str_replace('/creer-mon-profil/', $cta['url'], $content);
+         $content = str_replace('Créer mon profil', $cta['label'], $content);
+         echo $content;
       }
     ?>
 </main>


### PR DESCRIPTION
## Summary
- add helper to compute organiser CTA
- redirect profile creation flow back to `devenir-organisateur`
- show confirmation notice on organiser page
- update hero and final CTA text and link dynamically

## Testing
- `composer install` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b9ed879048332b9af99947e9a9ad9