### PR TITLE
Fix redirect conditions on organizer page

### DIFF
--- a/inc/edition/edition-organisateur.php
+++ b/inc/edition/edition-organisateur.php
@@ -314,6 +314,25 @@ function rediriger_selon_etat_organisateur()
     return; // Aucun organisateur : accès au canevas autorisé
   }
 
+  $user  = wp_get_current_user();
+  $roles = (array) $user->roles;
+
+  $has_chasse_non_attente = false;
+  $query = get_chasses_de_organisateur($organisateur_id);
+  if ($query && $query->have_posts()) {
+    foreach ($query->posts as $chasse) {
+      $statut_validation = get_field('champs_caches_chasse_cache_statut_validation', $chasse->ID);
+      if ($statut_validation !== 'en_attente') {
+        $has_chasse_non_attente = true;
+        break;
+      }
+    }
+  }
+
+  if ((in_array(ROLE_ORGANISATEUR_CREATION, $roles, true) || in_array(ROLE_ORGANISATEUR, $roles, true)) && $has_chasse_non_attente) {
+    return; // Laisser accès à la page, pas de redirection
+  }
+
   $post = get_post($organisateur_id);
 
   switch ($post->post_status) {


### PR DESCRIPTION
## Summary
- adjust `rediriger_selon_etat_organisateur` to let organizers access the page when a related hunt is not pending

## Testing
- `composer install` *(fails: command not found)*
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_685ba26b64a88332865933939ee29be5