### PR TITLE
Show pending organisers list for admins

### DIFF
--- a/templates/admin/organisateurs.php
+++ b/templates/admin/organisateurs.php
@@ -12,58 +12,8 @@ $current_user = wp_get_current_user();
 $logout_url = wc_get_account_endpoint_url('customer-logout'); // Lien déconnexion
 
 
-// Récupérer tous les utilisateurs ayant le rôle "organisateur_creation"
-$utilisateurs = get_users(['role' => ROLE_ORGANISATEUR_CREATION]);
-
-$organisateurs_liste = []; // Stocker les résultats trouvés
-
-foreach ($utilisateurs as $user) {
-    // Récupérer l'ID du CPT "organisateur" associé à l'utilisateur
-    $organisateur_id = get_organisateur_from_user($user->ID);
-    if (!$organisateur_id) continue;
-
-    // Récupérer les chasses associées à l'organisateur
-    $chasses = get_chasses_de_organisateur($organisateur_id);
-
-    // Vérifier si une chasse a `champs_caches_statut_validation` = "creation"
-    $chasse_associee = null;
-    while ($chasses->have_posts()) : $chasses->the_post();
-        $statut_validation = get_field('champs_caches_statut_validation'); // Vérification du champ ACF
-        if ($statut_validation === 'creation') {
-            $chasse_associee = get_the_ID();
-            break;
-        }
-    endwhile;
-    wp_reset_postdata();
-
-    if (!$chasse_associee) continue;
-
-    // Récupérer le nombre d'énigmes associées
-    $enigmes_associees = recuperer_enigmes_associees($chasse_associee);
-    $total_enigmes = count($enigmes_associees);
-
-    // Récupérer la date de dernière modification des CPT
-    $organisateur_mod_date = get_the_modified_date('d/m/Y', $organisateur_id);
-    $chasse_mod_date = get_the_modified_date('d/m/Y', $chasse_associee);
-
-    // URL de prévisualisation du CPT (pour statut pending)
-    $organisateur_preview_url = get_preview_post_link($organisateur_id);
-    $chasse_preview_url = get_preview_post_link($chasse_associee);
-
-    // Ajouter à la liste des résultats
-    $organisateurs_liste[] = [
-        'user_name' => $user->display_name,
-        'organisateur_id' => $organisateur_id,
-        'organisateur_titre' => get_the_title($organisateur_id),
-        'organisateur_preview_url' => $organisateur_preview_url,
-        'organisateur_mod_date' => $organisateur_mod_date,
-        'chasse_id' => $chasse_associee,
-        'chasse_titre' => get_the_title($chasse_associee),
-        'chasse_preview_url' => $chasse_preview_url,
-        'chasse_mod_date' => $chasse_mod_date,
-        'total_enigmes' => $total_enigmes,
-    ];
-}
+// Récupérer la liste des organisateurs en attente de validation
+$organisateurs_liste = recuperer_organisateurs_pending();
 
 ?>
 <div id="primary" class="content-area primary ">
@@ -143,34 +93,36 @@ foreach ($utilisateurs as $user) {
                     // Vérifier s'il y a des résultats avant d'afficher le tableau
 if (!empty($organisateurs_liste)) :
 ?>
-    <h3>Organisateurs : création en cours</h3>
+    <h3>Organisateurs en attente</h3>
     <span><?php echo count($organisateurs_liste); ?> résultat(s) trouvé(s)</span>
     <table class="table-organisateurs">
         <thead>
             <tr>
-                <th>Utilisateur</th>
                 <th>Organisateur</th>
                 <th>Chasse</th>
                 <th>Nb Énigmes</th>
+                <th>Créé le</th>
             </tr>
         </thead>
         <tbody>
             <?php foreach ($organisateurs_liste as $entry) : ?>
                 <tr>
-                    <td><?php echo esc_html($entry['user_name']); ?></td>
-                    <td>
-                        <a href="<?php echo esc_url($entry['organisateur_preview_url']); ?>" target="_blank">
+                    <td class="<?php echo $entry['organisateur_complet'] ? 'carte-complete' : 'carte-incomplete'; ?>">
+                        <a href="<?php echo esc_url($entry['organisateur_permalink']); ?>" target="_blank">
                             <?php echo esc_html($entry['organisateur_titre']); ?>
                         </a>
-                        <br><small>Dernière modif : <?php echo esc_html($entry['organisateur_mod_date']); ?></small>
                     </td>
                     <td>
-                        <a href="<?php echo esc_url($entry['chasse_preview_url']); ?>" target="_blank">
-                            <?php echo esc_html($entry['chasse_titre']); ?>
-                        </a>
-                        <br><small>Dernière modif : <?php echo esc_html($entry['chasse_mod_date']); ?></small>
+                        <?php if ($entry['chasse_id']) : ?>
+                            <a class="<?php echo $entry['chasse_complet'] ? 'carte-complete' : 'carte-incomplete'; ?>" href="<?php echo esc_url($entry['chasse_permalink']); ?>" target="_blank">
+                                <?php echo esc_html($entry['chasse_titre']); ?>
+                            </a>
+                        <?php else : ?>
+                            -
+                        <?php endif; ?>
                     </td>
-                    <td><?php echo esc_html($entry['total_enigmes']); ?></td>
+                    <td><?php echo esc_html($entry['nb_enigmes']); ?></td>
+                    <td><?php echo esc_html(date('Y-m-d', strtotime($entry['date_creation']))); ?></td>
                 </tr>
             <?php endforeach; ?>
         </tbody>


### PR DESCRIPTION
## Summary
- list pending organisateur posts for admins
- mark completion of organisers and chasses in the table

## Testing
- `composer install`
- `vendor/bin/phpunit --configuration tests/phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_685ba1b47be08332800409b5db1f88fe