### PR TITLE
Fix redirect conditions on organizer page

### DIFF
--- a/inc/edition/edition-organisateur.php
+++ b/inc/edition/edition-organisateur.php
@@ -314,6 +314,25 @@ function rediriger_selon_etat_organisateur()
     return; // Aucun organisateur : accès au canevas autorisé
   }
 
+  $user  = wp_get_current_user();
+  $roles = (array) $user->roles;
+
+  $has_chasse_non_attente = false;
+  $query = get_chasses_de_organisateur($organisateur_id);
+  if ($query && $query->have_posts()) {
+    foreach ($query->posts as $chasse) {
+      $statut_validation = get_field('champs_caches_chasse_cache_statut_validation', $chasse->ID);
+      if ($statut_validation !== 'en_attente') {
+        $has_chasse_non_attente = true;
+        break;
+      }
+    }
+  }
+
+  if ((in_array(ROLE_ORGANISATEUR_CREATION, $roles, true) || in_array(ROLE_ORGANISATEUR, $roles, true)) && $has_chasse_non_attente) {
+    return; // Laisser accès à la page, pas de redirection
+  }
+
   $post = get_post($organisateur_id);
 
   switch ($post->post_status) {

--- a/templates/page-creer-profil.php
+++ b/templates/page-creer-profil.php
@@ -14,8 +14,9 @@ if (!is_user_logged_in()) {
 
 $current_user_id = get_current_user_id();
 
-// 2. Si un profil existe déjà, redirection automatique
-rediriger_selon_etat_organisateur();
+// 2. Si un profil existe déjà, on n'effectue plus de redirection automatique
+// vers l'espace organisateur. Le bouton principal se charge de guider
+// l'utilisateur selon l'état de son profil.
 
 // 3. Gestion de la demande en cours
 if (isset($_GET['resend'])) {

--- a/templates/page-devenir-organisateur.php
+++ b/templates/page-devenir-organisateur.php
@@ -27,8 +27,9 @@ acf_form_head(); // ✅ nécessaire pour ACF frontend
 $user_id = get_current_user_id();
 $organisateur_id = get_organisateur_from_user($user_id);
 
-// 👉 maintenant que le CPT existe (ou pas), on peut rediriger
-rediriger_selon_etat_organisateur();
+// 👉 l'accès à cette page est désormais autorisé pour les organisateurs ayant
+// au moins une chasse non en attente de validation. La redirection automatique
+// n'est donc plus nécessaire et est gérée via le CTA dynamique.
 
 // Image par défaut au cas où aucune miniature n'est définie
 $image_url = '';


### PR DESCRIPTION
## Summary
- adjust `rediriger_selon_etat_organisateur` to let organizers access the page when a related hunt is not pending
- remove legacy redirects from organizer templates

## Testing
- `composer install` *(fails: command not found)*
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_685ba26b64a88332865933939ee29be5