### PR TITLE
Add admin validation actions

### DIFF
--- a/inc/admin-functions.php
+++ b/inc/admin-functions.php
@@ -1472,15 +1472,17 @@ function recuperer_organisateurs_pending() {
 /**
  * Affiche la liste des organisateurs en attente dans un tableau.
  */
-function afficher_tableau_organisateurs_pending() {
-    $liste = recuperer_organisateurs_pending();
+function afficher_tableau_organisateurs_pending($liste = null) {
+    if ($liste === null) {
+        $liste = recuperer_organisateurs_pending();
+    }
     if (empty($liste)) {
         echo '<p>Aucun organisateur en attente.</p>';
         return;
     }
 
     echo '<table class="table-organisateurs">';
-    echo '<thead><tr><th>Organisateur</th><th>Chasse</th><th>Utilisateur</th><th>Créé le</th></tr></thead><tbody>';
+    echo '<thead><tr><th>Organisateur</th><th>Chasse</th><th>Utilisateur</th><th>Créé le</th><th>Actions</th></tr></thead><tbody>';
 
     foreach ($liste as $entry) {
         $class_org = $entry['organisateur_complet'] ? 'carte-complete' : 'carte-incomplete';
@@ -1504,6 +1506,23 @@ function afficher_tableau_organisateurs_pending() {
             echo '<td>-</td>';
         }
         echo '<td>' . esc_html(date_i18n('d/m/y', strtotime($entry['date_creation']))) . '</td>';
+
+        echo '<td>';
+        if ($entry['chasse_id']) {
+            $nonce = wp_create_nonce('validation_admin_' . $entry['chasse_id']);
+            echo '<form method="post" action="' . esc_url(admin_url('admin-post.php')) . '" class="form-validation-admin">';
+            echo '<input type="hidden" name="action" value="traiter_validation_chasse">';
+            echo '<input type="hidden" name="chasse_id" value="' . intval($entry['chasse_id']) . '">';
+            echo '<input type="hidden" name="validation_admin_nonce" value="' . esc_attr($nonce) . '">';
+            echo '<button type="submit" name="validation_admin_action" value="valider" class="button">Valider</button> ';
+            echo '<button type="submit" name="validation_admin_action" value="correction" class="button">Correction</button> ';
+            echo '<button type="submit" name="validation_admin_action" value="bannir" class="button">Bannir</button> ';
+            echo '<button type="submit" name="validation_admin_action" value="supprimer" class="button" onclick="return confirm(\'Confirmer la suppression ?\');">Supprimer</button>';
+            echo '</form>';
+        } else {
+            echo '-';
+        }
+        echo '</td>';
         echo '</tr>';
     }
 

--- a/templates/admin/organisateurs.php
+++ b/templates/admin/organisateurs.php
@@ -12,8 +12,6 @@ $current_user = wp_get_current_user();
 $logout_url = wc_get_account_endpoint_url('customer-logout'); // Lien déconnexion
 
 
-// Récupérer la liste des organisateurs en attente de validation
-$organisateurs_liste = recuperer_organisateurs_pending();
 
 ?>
 <div id="primary" class="content-area primary ">
@@ -91,58 +89,14 @@ $organisateurs_liste = recuperer_organisateurs_pending();
                     <?php 
                     
                     // Vérifier s'il y a des résultats avant d'afficher le tableau
+$organisateurs_liste = recuperer_organisateurs_pending();
 if (!empty($organisateurs_liste)) :
+    echo '<h3>Organisateurs en attente</h3>';
+    echo '<span>' . count($organisateurs_liste) . ' résultat(s) trouvé(s)</span>';
+    afficher_tableau_organisateurs_pending($organisateurs_liste);
+endif;
 ?>
-    <h3>Organisateurs en attente</h3>
-    <span><?php echo count($organisateurs_liste); ?> résultat(s) trouvé(s)</span>
-    <table class="table-organisateurs">
-        <thead>
-            <tr>
-                <th>Organisateur</th>
-                <th>Chasse</th>
-                <th>Utilisateur</th>
-                <th>Créé le</th>
-            </tr>
-        </thead>
-        <tbody>
-            <?php foreach ($organisateurs_liste as $entry) : ?>
-                <tr class="<?php echo $entry['validation'] === 'en_attente' ? 'champ-attention' : ''; ?>">
-                    <td class="<?php echo $entry['organisateur_complet'] ? 'carte-complete' : 'carte-incomplete'; ?>">
-                        <a href="<?php echo esc_url($entry['organisateur_permalink']); ?>" target="_blank">
-                            <?php echo esc_html($entry['organisateur_titre']); ?>
-                        </a>
-                    </td>
-                    <td>
-                        <?php if ($entry['chasse_id']) : ?>
-                            <?php
-                                $titre_chasse = $entry['chasse_titre'];
-                                if ($entry['nb_enigmes']) {
-                                    $titre_chasse .= ' (' . intval($entry['nb_enigmes']) . ')';
-                                }
-                            ?>
-                            <a class="<?php echo $entry['chasse_complet'] ? 'carte-complete' : 'carte-incomplete'; ?>" href="<?php echo esc_url($entry['chasse_permalink']); ?>" target="_blank">
-                                <?php echo esc_html($titre_chasse); ?>
-                            </a>
-                        <?php else : ?>
-                            -
-                        <?php endif; ?>
-                    </td>
-                    <td>
-                        <?php if ($entry['user_id']) : ?>
-                            <a href="<?php echo esc_url($entry['user_link']); ?>" target="_blank">
-                                <?php echo esc_html($entry['user_name']); ?>
-                            </a>
-                        <?php else : ?>-
-                        <?php endif; ?>
-                    </td>
-                    <td><?php echo esc_html(date_i18n('d/m/y', strtotime($entry['date_creation']))); ?></td>
-                </tr>
-            <?php endforeach; ?>
-        </tbody>
-    </table>
-<?php endif; // Fin de la condition ?>
-   
-                    
+
                 </div>
             </div>
         


### PR DESCRIPTION
## Summary
- add optional param to afficher_tableau_organisateurs_pending
- show admin validation buttons for each chasse
- refactor organiser admin template to reuse helper function

## Testing
- `phpunit -c tests/phpunit.xml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c09eb83408332813b73f5c9ea117b