### PR TITLE
Add admin validation UI for chasses

### DIFF
--- a/single-chasse.php
+++ b/single-chasse.php
@@ -58,6 +58,8 @@ $total_enigmes = count($enigmes_associees);
 $enigmes_resolues = compter_enigmes_resolues($chasse_id, $user_id);
 
 $statut = get_field('champs_caches')['chasse_cache_statut'] ?? 'revision';
+$cache_global = get_field('champs_caches', $chasse_id);
+$statut_validation = $cache_global['chasse_cache_statut_validation'] ?? '';
 $nb_joueurs = 0;
 
 get_header();
@@ -87,6 +89,14 @@ $validation_envoyee = !empty($_GET['validation_demandee']);
       }
       if ($validation_envoyee) {
         echo '<p class="message-succes">✅ Votre demande de validation a bien été envoyée. Elle sera traitée par l’équipe.</p>';
+      }
+      ?>
+
+      <?php
+      if (current_user_can('administrator') && $statut_validation === 'en_attente') {
+        get_template_part('template-parts/chasse/chasse-validation-actions', null, [
+          'chasse_id' => $chasse_id,
+        ]);
       }
       ?>
 

--- a/template-parts/chasse/chasse-validation-actions.php
+++ b/template-parts/chasse/chasse-validation-actions.php
@@ -1,0 +1,28 @@
+<?php
+defined('ABSPATH') || exit;
+
+$chasse_id = $args['chasse_id'] ?? null;
+if (!$chasse_id || get_post_type($chasse_id) !== 'chasse') {
+    return;
+}
+
+$organisateur_id = get_organisateur_from_chasse($chasse_id);
+$org_status = $organisateur_id ? get_post_status($organisateur_id) : '';
+$titre_bloc = $org_status === 'pending'
+    ? "traitement d'une création de chasse"
+    : "demande de validation nouvelle chasse";
+?>
+<section class="bloc-traitement-validation-chasse">
+  <h2><?php echo esc_html($titre_bloc); ?></h2>
+  <form method="post" action="<?php echo esc_url(admin_url('admin-post.php')); ?>" class="form-traitement-validation-chasse">
+    <?php wp_nonce_field('validation_admin_' . $chasse_id, 'validation_admin_nonce'); ?>
+    <input type="hidden" name="action" value="traiter_validation_chasse">
+    <input type="hidden" name="chasse_id" value="<?php echo esc_attr($chasse_id); ?>">
+    <div class="boutons">
+      <button type="submit" name="validation_admin_action" value="valider" class="btn btn-valider">✅ Valider la chasse</button>
+      <button type="submit" name="validation_admin_action" value="correction" class="btn btn-correction">✍️ Correction</button>
+      <button type="submit" name="validation_admin_action" value="bannir" class="btn btn-bannir">❌ Bannir</button>
+      <button type="submit" name="validation_admin_action" value="supprimer" class="btn btn-warning" onclick="return confirm('Supprimer cette chasse ?');">🗑️ Supprimer</button>
+    </div>
+  </form>
+</section>


### PR DESCRIPTION
## Summary
- add a template part with validation action buttons
- show admin validation block on single chasse page with dynamic title
- compute validation status for the current chasse

## Testing
- `composer install`
- `vendor/bin/phpunit --configuration tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_685c0ad8f15883328a391db880cb21d4