### PR TITLE
Fix strtolower null in chasse functions

### DIFF
--- a/inc/chasse-functions.php
+++ b/inc/chasse-functions.php
@@ -408,8 +408,8 @@ function solution_peut_etre_affichee(int $enigme_id): bool
         return false;
     }
 
-    $statut = get_field('statut_chasse', $chasse_id);
-    $terminee = in_array(strtolower($statut), ['terminée', 'termine', 'terminé'], true);
+    $statut   = get_field('statut_chasse', $chasse_id);
+    $terminee = is_string($statut) && in_array(strtolower($statut), ['terminée', 'termine', 'terminé'], true);
     if (!$terminee) {
         return false;
     }


### PR DESCRIPTION
## Summary
- avoid deprecated `strtolower(null)` in `solution_peut_etre_affichee`

## Testing
- `apt-get update`
- `apt-get install -y php-cli php-mbstring php-xml unzip`
- `php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_685c0e5b6c408332923f22a50e3aaf94