### PR TITLE
Fix admin validation redirect

### DIFF
--- a/inc/admin-functions.php
+++ b/inc/admin-functions.php
@@ -1611,7 +1611,9 @@ function traiter_validation_chasse_admin() {
         wp_trash_post($chasse_id);
     }
 
-    wp_safe_redirect(wp_get_referer() ?: home_url('/')); 
+    // Après le traitement, rediriger systématiquement vers la liste des
+    // organisateurs afin d'éviter une erreur 404 si la chasse n'existe plus.
+    wp_safe_redirect(home_url('/mon-compte/organisateurs/'));
     exit;
 }
 add_action('admin_post_traiter_validation_chasse', 'traiter_validation_chasse_admin');


### PR DESCRIPTION
## Summary
- redirect to the organisers overview after validation actions

## Testing
- `phpunit --configuration tests/phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_685c13596aa88332bd27b6d82fef6f63