### PR TITLE
Add datetime scheduling for hunts and enigmas

### DIFF
--- a/assets/css/edition.css
+++ b/assets/css/edition.css
@@ -350,7 +350,8 @@ body.edition-active .header-organisateur-wrapper .champ-modifier:focus {
 }
 
 /* ========== 📅 CHAMPS DATES — AFFICHAGE ET COMPORTEMENT ========== */
-input[type=date].champ-date-edit {
+input[type=date].champ-date-edit,
+input[type=datetime-local].champ-date-edit {
   width: auto;
 }
 

--- a/assets/js/chasse-edit.js
+++ b/assets/js/chasse-edit.js
@@ -210,13 +210,19 @@ document.addEventListener('DOMContentLoaded', () => {
         return;
       }
 
-      const nouvelleDateDebut = this.value;
+      const nouvelleDateDebutBrute = this.value;
       const regexDate = /^\d{4}-\d{2}-\d{2}$/;
+      const regexDateTime = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}$/;
 
-      if (!regexDate.test(nouvelleDateDebut)) {
-        console.error('❌ Format de date début invalide:', nouvelleDateDebut);
+      if (!regexDate.test(nouvelleDateDebutBrute) && !regexDateTime.test(nouvelleDateDebutBrute)) {
+        console.error('❌ Format de date début invalide:', nouvelleDateDebutBrute);
         this.value = ancienneValeurDebut;
         return;
+      }
+
+      let nouvelleDateDebut = nouvelleDateDebutBrute;
+      if (regexDateTime.test(nouvelleDateDebutBrute)) {
+        nouvelleDateDebut = nouvelleDateDebutBrute.replace('T', ' ') + ':00';
       }
 
       const postId = this.closest('.champ-chasse')?.dataset.postId;

--- a/assets/js/core/date-fields.js
+++ b/assets/js/core/date-fields.js
@@ -1,5 +1,7 @@
 document.addEventListener('DOMContentLoaded', () => {
-  document.querySelectorAll('input[type="date"]').forEach(initChampDate);
+  document
+    .querySelectorAll('input[type="date"], input[type="datetime-local"]')
+    .forEach(initChampDate);
 });
 
 
@@ -9,6 +11,12 @@ document.addEventListener('DOMContentLoaded', () => {
 // ==============================
 function formatDateFr(dateStr) {
   if (!dateStr) return '';
+  if (dateStr.includes('T')) {
+    const [datePart, timePart] = dateStr.split('T');
+    const parts = datePart.split('-');
+    if (parts.length !== 3) return dateStr;
+    return `${parts[2]}/${parts[1]}/${parts[0]} ${timePart}`;
+  }
   const parts = dateStr.split('-');
   if (parts.length !== 3) return dateStr;
   return `${parts[2]}/${parts[1]}/${parts[0]}`;
@@ -51,18 +59,25 @@ function initChampDate(input) {
   // 🕒 Pré-remplissage si vide
   if (!input.value && bloc.dataset.date) {
     const dateInit = bloc.dataset.date;
-    if (/^\d{4}-\d{2}-\d{2}$/.test(dateInit)) {
+    if (/^\d{4}-\d{2}-\d{2}(T\d{2}:\d{2})?$/.test(dateInit)) {
       input.value = dateInit;
     }
   }
 
   input.addEventListener('change', () => {
-    const valeur = input.value.trim();
-    console.log('[🧪 initChampDate]', champ, '| valeur saisie :', valeur);
-    if (!/^\d{4}-\d{2}-\d{2}$/.test(valeur)) {
-      console.warn(`❌ Date invalide (${champ}) :`, valeur);
+    const valeurBrute = input.value.trim();
+    console.log('[🧪 initChampDate]', champ, '| valeur saisie :', valeurBrute);
+    const regexDate = /^\d{4}-\d{2}-\d{2}$/;
+    const regexDateTime = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}$/;
+    if (!regexDate.test(valeurBrute) && !regexDateTime.test(valeurBrute)) {
+      console.warn(`❌ Date invalide (${champ}) :`, valeurBrute);
       input.value = input.dataset.previous || '';
       return;
+    }
+
+    let valeur = valeurBrute;
+    if (regexDateTime.test(valeurBrute)) {
+      valeur = valeurBrute.replace('T', ' ') + ':00';
     }
 
     if (cpt === 'chasse' && typeof window.validerDatesAvantEnvoi === 'function') {

--- a/inc/edition/edition-chasse.php
+++ b/inc/edition/edition-chasse.php
@@ -129,7 +129,7 @@ function creer_chasse_et_rediriger_si_appel()
 
 
   // 📅 Préparation des valeurs
-  $today = current_time('Y-m-d');
+  $today = current_time('Y-m-d H:i:s');
   $in_two_years = date('Y-m-d', strtotime('+2 years'));
 
   // ✅ Initialisation des groupes ACF
@@ -268,16 +268,26 @@ function modifier_champ_chasse()
   }
 
   // 🔹 Dates (début / fin)
-  $champs_dates = [
-    'caracteristiques.chasse_infos_date_debut',
-    'caracteristiques.chasse_infos_date_fin'
-  ];
-  if (in_array($champ, $champs_dates, true)) {
+  if ($champ === 'caracteristiques.chasse_infos_date_debut') {
+    if (!preg_match('/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}$/', $valeur)) {
+      wp_send_json_error('⚠️ format_date_invalide');
+    }
+    $dt = DateTime::createFromFormat('Y-m-d\TH:i', $valeur);
+    if ($dt) {
+      $valeur = $dt->format('Y-m-d H:i:s');
+    }
+    $ok = mettre_a_jour_sous_champ_group($post_id, 'caracteristiques', 'chasse_infos_date_debut', $valeur);
+    if ($ok) {
+      $champ_valide = true;
+      $doit_recalculer_statut = true;
+    }
+  }
+
+  if ($champ === 'caracteristiques.chasse_infos_date_fin') {
     if (!preg_match('/^\d{4}-\d{2}-\d{2}$/', $valeur)) {
       wp_send_json_error('⚠️ format_date_invalide');
     }
-    $sous_champ = str_replace('caracteristiques.', '', $champ);
-    $ok = mettre_a_jour_sous_champ_group($post_id, 'caracteristiques', $sous_champ, $valeur);
+    $ok = mettre_a_jour_sous_champ_group($post_id, 'caracteristiques', 'chasse_infos_date_fin', $valeur);
     if ($ok) {
       $champ_valide = true;
       $doit_recalculer_statut = true;

--- a/inc/edition/edition-enigme.php
+++ b/inc/edition/edition-enigme.php
@@ -105,7 +105,7 @@ function creer_enigme_pour_chasse($chasse_id, $user_id = null)
   update_field('enigme_acces_condition', 'immediat', $enigme_id);
   update_field('enigme_acces_pre_requis', [], $enigme_id);
 
-  $date_deblocage = (new DateTime('+1 month'))->format('Y-m-d');
+  $date_deblocage = (new DateTime('+1 month'))->format('Y-m-d H:i:s');
   update_field('enigme_acces_date', $date_deblocage, $enigme_id);
 
   // Calcule l\'état système initial pour permettre l\'édition complète
@@ -289,11 +289,16 @@ function modifier_champ_enigme()
 
   // 🔹 Accès : date
   if ($champ === 'enigme_acces_date') {
-    if (!preg_match('/^\d{4}-\d{2}-\d{2}$/', $valeur)) {
+    if (!preg_match('/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}$/', $valeur)) {
       wp_send_json_error('⚠️ format_date_invalide');
     }
 
-    $timestamp = strtotime($valeur);
+    $dt = DateTime::createFromFormat('Y-m-d\TH:i', $valeur);
+    if (!$dt) {
+      wp_send_json_error('⚠️ format_date_invalide');
+    }
+    $timestamp = $dt->getTimestamp();
+    $valeur_mysql = $dt->format('Y-m-d H:i:s');
     $today = strtotime(date('Y-m-d'));
     $mode = get_field('enigme_acces_condition', $post_id);
 
@@ -301,9 +306,8 @@ function modifier_champ_enigme()
       update_field('enigme_acces_condition', 'immediat', $post_id);
     }
 
-    $ok = update_field($champ, $valeur, $post_id);
-    $relue = get_field($champ, $post_id);
-    if ($ok || substr($relue, 0, 10) === $valeur) {
+    $ok = update_field($champ, $valeur_mysql, $post_id);
+    if ($ok) {
       $champ_valide = true;
     }
 

--- a/inc/statut-functions.php
+++ b/inc/statut-functions.php
@@ -759,8 +759,10 @@ function mettre_a_jour_statuts_chasse($chasse_id)
     $maintenant = current_time('timestamp');
 
     $statut_validation = $cache['chasse_cache_statut_validation'] ?? 'creation';
-    $date_debut        = !empty($carac['chasse_infos_date_debut']) ? strtotime($carac['chasse_infos_date_debut']) : null;
-    $date_fin          = !empty($carac['chasse_infos_date_fin']) ? strtotime($carac['chasse_infos_date_fin']) : null;
+    $date_debut_obj    = convertir_en_datetime($carac['chasse_infos_date_debut'] ?? null);
+    $date_debut        = $date_debut_obj ? $date_debut_obj->getTimestamp() : null;
+    $date_fin_obj      = convertir_en_datetime($carac['chasse_infos_date_fin'] ?? null);
+    $date_fin          = $date_fin_obj ? $date_fin_obj->getTimestamp() : null;
     $date_obj          = convertir_en_datetime($cache['chasse_cache_date_decouverte'] ?? null);
     $date_decouverte   = $date_obj ? $date_obj->getTimestamp() : null;
     $cout_points       = intval($carac['chasse_infos_cout_points'] ?? 0);

--- a/template-parts/chasse/chasse-edition-main.php
+++ b/template-parts/chasse/chasse-edition-main.php
@@ -26,6 +26,13 @@ $valeur     = $carac['chasse_infos_recompense_valeur'] ?? '';
 $cout       = $carac['chasse_infos_cout_points'] ?? '';
 $date_debut = $carac['chasse_infos_date_debut'] ?? '';
 $date_fin   = $carac['chasse_infos_date_fin'] ?? '';
+
+// 🎯 Conversion des dates pour les champs <input>
+$date_debut_obj = convertir_en_datetime($date_debut);
+$date_debut_iso = $date_debut_obj ? $date_debut_obj->format('Y-m-d\TH:i') : '';
+
+$date_fin_obj = convertir_en_datetime($date_fin);
+$date_fin_iso = $date_fin_obj ? $date_fin_obj->format('Y-m-d') : '';
 $illimitee  = $carac['chasse_infos_duree_illimitee'] ?? false;
 $nb_max     = $carac['chasse_infos_nb_max_gagants'] ?? 1;
 
@@ -179,11 +186,11 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
                   data-cpt="chasse"
                   data-post-id="<?= esc_attr($chasse_id); ?>">
 
-                  <label for="chasse-date-debut">Date de début</label>
-                  <input type="date"
+                  <label for="chasse-date-debut">Date et heure de début</label>
+                  <input type="datetime-local"
                     id="chasse-date-debut"
                     name="chasse-date-debut"
-                    value="<?= esc_attr($date_debut); ?>"
+                    value="<?= esc_attr($date_debut_iso); ?>"
                     class="champ-inline-date champ-date-edit" <?= $peut_editer ? '' : 'disabled'; ?> required />
                   <div id="erreur-date-debut" class="message-erreur" style="display:none; color:red; font-size:0.9em; margin-top:5px;"></div>
 
@@ -199,7 +206,7 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
                   <input type="date"
                     id="chasse-date-fin"
                     name="chasse-date-fin"
-                    value="<?= esc_attr($date_fin); ?>"
+                    value="<?= esc_attr($date_fin_iso); ?>"
                     class="champ-inline-date champ-date-edit" <?= $peut_editer ? '' : 'disabled'; ?> />
                   <div id="erreur-date-fin" class="message-erreur" style="display:none; color:red; font-size:0.9em; margin-top:5px;"></div>
 

--- a/template-parts/enigme/enigme-edition-main.php
+++ b/template-parts/enigme/enigme-edition-main.php
@@ -33,7 +33,8 @@ $mode_validation = get_field('enigme_mode_validation', $enigme_id) ?? 'aucune';
 $style = get_field('enigme_style_affichage', $enigme_id);
 $solution = get_field('enigme_solution', $enigme_id);
 $date_raw = get_field('enigme_acces_date', $enigme_id);
-$date_deblocage = $date_raw ? substr($date_raw, 0, 10) : '';
+$date_obj = convertir_en_datetime($date_raw);
+$date_deblocage = $date_obj ? $date_obj->format('Y-m-d\TH:i') : '';
 
 
 $chasse = get_field('enigme_chasse_associee', $enigme_id);
@@ -247,8 +248,8 @@ $has_variantes = ($nb_variantes > 0);
               </div>
 
               <div class="champ-enigme champ-date cache<?= $peut_editer ? '' : ' champ-desactive'; ?>" data-champ="enigme_acces_date" data-cpt="enigme" data-post-id="<?= esc_attr($enigme_id); ?>" id="champ-enigme-date">
-                <label for="enigme-date-deblocage">Date de déblocage</label>
-                <input type="date"
+                <label for="enigme-date-deblocage">Date et heure de déblocage</label>
+                <input type="datetime-local"
                   id="enigme-date-deblocage"
                   name="enigme-date-deblocage"
                   value="<?= esc_attr($date_deblocage); ?>"


### PR DESCRIPTION
## Summary
- support datetime-local input for hunt and enigma start
- convert ISO datetime values when saving
- adapt JS date helpers for datetime
- keep status calculations working with new format
- tweak styles for datetime inputs

## Testing
- `vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c123b59dc833285c10aaa1c28d96a