### PR TITLE
Implement correction modal for admin validation

### DIFF
--- a/assets/css/organisateurs.css
+++ b/assets/css/organisateurs.css
@@ -601,3 +601,22 @@ section#presentation .presentation-fermer {
         height: 40px;
     }
 }
+
+/* ========== ✍️ MODAL DEMANDE DE CORRECTION ========== */
+.modal-correction-chasse {
+  position: fixed;
+  z-index: 9999;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.65);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  animation: fadeIn 0.3s ease-in-out;
+}
+.modal-correction-chasse textarea {
+  width: 100%;
+  margin-top: 1rem;
+  padding: 0.5rem;
+  font-size: 1rem;
+  resize: vertical;
+}

--- a/assets/js/validation-admin.js
+++ b/assets/js/validation-admin.js
@@ -1,0 +1,57 @@
+document.addEventListener('DOMContentLoaded', () => {
+  document.addEventListener('click', (e) => {
+    const btn = e.target.closest('.form-traitement-validation-chasse .btn-correction');
+    if (!btn) return;
+
+    e.preventDefault();
+    const form = btn.closest('form');
+    if (!form) return;
+
+    ouvrirModalCorrection(form);
+  });
+});
+
+function ouvrirModalCorrection(form) {
+  document.querySelector('.modal-correction-chasse')?.remove();
+
+  const modal = document.createElement('div');
+  modal.className = 'modal-correction-chasse';
+  modal.innerHTML = `
+    <div class="modal-contenu">
+      <button class="modal-close-top" aria-label="Fermer">&times;</button>
+      <h2>Demande de correction</h2>
+      <textarea class="message-correction" rows="5" placeholder="Message pour l'organisateur"></textarea>
+      <div class="boutons-modal">
+        <button class="valider-correction">Valider</button>
+        <button class="annuler-correction">Annuler</button>
+      </div>
+    </div>`;
+
+  document.body.appendChild(modal);
+
+  const fermer = () => modal.remove();
+
+  modal.querySelector('.modal-close-top').addEventListener('click', fermer);
+  modal.querySelector('.annuler-correction').addEventListener('click', fermer);
+  modal.addEventListener('click', (e) => {
+    if (e.target === modal) fermer();
+  });
+
+  modal.querySelector('.valider-correction').addEventListener('click', () => {
+    const message = modal.querySelector('.message-correction').value;
+    const inputAction = document.createElement('input');
+    inputAction.type = 'hidden';
+    inputAction.name = 'validation_admin_action';
+    inputAction.value = 'correction';
+    form.appendChild(inputAction);
+
+    const inputMsg = document.createElement('input');
+    inputMsg.type = 'hidden';
+    inputMsg.name = 'validation_admin_message';
+    inputMsg.value = message;
+    form.appendChild(inputMsg);
+
+    fermer();
+    form.submit();
+  });
+}

--- a/inc/layout-functions.php
+++ b/inc/layout-functions.php
@@ -147,6 +147,14 @@ function charger_scripts_personnalises() {
       filemtime(get_stylesheet_directory() . '/assets/js/validation-chasse.js'),
       true
     );
+
+    wp_enqueue_script(
+      'validation-admin',
+      $theme_dir . 'validation-admin.js',
+      [],
+      filemtime(get_stylesheet_directory() . '/assets/js/validation-admin.js'),
+      true
+    );
 }
 // ✅ Ajout des scripts au chargement de WordPress
 add_action('wp_enqueue_scripts', 'charger_scripts_personnalises');


### PR DESCRIPTION
## Summary
- add frontend modal for admin correction workflow
- style the new correction modal
- load the new script from theme functions

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c1a6381088332b8752f08015278a1