### PR TITLE
Fix chasse field updates

### DIFF
--- a/assets/js/chasse-edit.js
+++ b/assets/js/chasse-edit.js
@@ -190,7 +190,7 @@ document.addEventListener('DOMContentLoaded', () => {
       }
 
       const postId = this.closest('.champ-chasse')?.dataset.postId;
-      modifierChampSimple('caracteristiques.chasse_infos_date_fin', nouvelleDateFin, postId);
+      modifierChampSimple('caracteristiques.chasse_infos_date_fin', nouvelleDateFin, postId, 'chasse');
       rafraichirStatutChasse(postId);
 
       mettreAJourAffichageDateFin();
@@ -224,7 +224,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
 
       const postId = this.closest('.champ-chasse')?.dataset.postId;
-      modifierChampSimple('caracteristiques.chasse_infos_date_debut', nouvelleDateDebut, postId);
+      modifierChampSimple('caracteristiques.chasse_infos_date_debut', nouvelleDateDebut, postId, 'chasse');
       rafraichirStatutChasse(postId);
 
       ancienneValeurDebut = nouvelleDateDebutBrute;
@@ -530,7 +530,7 @@ document.querySelectorAll('.champ-cout-points .champ-enregistrer').forEach(bouto
 
     if (!champ || !postId) return;
 
-    modifierChampSimple(champ, valeur, postId);
+    modifierChampSimple(champ, valeur, postId, 'chasse');
 
     if (champ === 'caracteristiques.chasse_infos_cout_points') {
       mettreAJourAffichageCout(postId, valeur);
@@ -591,12 +591,12 @@ function initChampNbGagnants() {
     if (checkboxIllimite.checked) {
       inputNb.disabled = true;
       inputNb.value = '0';
-      modifierChampSimple('caracteristiques.chasse_infos_nb_max_gagants', 0, postId);
+      modifierChampSimple('caracteristiques.chasse_infos_nb_max_gagants', 0, postId, 'chasse');
     } else {
       inputNb.disabled = false;
       if (parseInt(inputNb.value.trim(), 10) === 0 || inputNb.value.trim() === '') {
         inputNb.value = '1';
-        modifierChampSimple('caracteristiques.chasse_infos_nb_max_gagants', 1, postId);
+        modifierChampSimple('caracteristiques.chasse_infos_nb_max_gagants', 1, postId, 'chasse');
       }
     }
     // 🔥 Mise à jour dynamique après changement illimité
@@ -614,7 +614,7 @@ function initChampNbGagnants() {
         valeur = 1;
         inputNb.value = '1';
       }
-      modifierChampSimple('caracteristiques.chasse_infos_nb_max_gagants', valeur, postId);
+      modifierChampSimple('caracteristiques.chasse_infos_nb_max_gagants', valeur, postId, 'chasse');
       mettreAJourAffichageNbGagnants(postId, valeur); // ✅ ici, APRES avoir défini valeur
     }, 500);
   });


### PR DESCRIPTION
## Summary
- ensure `modifierChampSimple` uses the `chasse` CPT when editing hunt fields

## Testing
- `composer install`
- `vendor/bin/phpunit --configuration tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_685c20688d608332b14be0e7eb8bf467