### PR TITLE
Fix date end field on chasse edit panel

### DIFF
--- a/assets/js/chasse-edit.js
+++ b/assets/js/chasse-edit.js
@@ -7,6 +7,8 @@ let inputDateFin;
 let erreurDebut;
 let erreurFin;
 let checkboxIllimitee;
+let ancienneValeurDebut = '';
+let ancienneValeurFin = '';
 
 
 document.addEventListener('DOMContentLoaded', () => {
@@ -100,6 +102,7 @@ document.addEventListener('DOMContentLoaded', () => {
   // 📅 Gestion Date de fin + Durée illimitée
   // ==============================
   if (inputDateFin && !inputDateFin.disabled) {
+    ancienneValeurFin = inputDateFin.value;
     if (checkboxIllimitee) {
       inputDateFin.disabled = checkboxIllimitee.checked;
       

--- a/template-parts/chasse/chasse-edition-main.php
+++ b/template-parts/chasse/chasse-edition-main.php
@@ -186,7 +186,7 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
                   data-cpt="chasse"
                   data-post-id="<?= esc_attr($chasse_id); ?>">
 
-                  <label for="chasse-date-debut">Date et heure de début</label>
+                  <label for="chasse-date-debut">Début</label>
                   <input type="datetime-local"
                     id="chasse-date-debut"
                     name="chasse-date-debut"


### PR DESCRIPTION
## Summary
- restore missing date tracking variables
- initialize the end date input value
- update label of start date field

## Testing
- `phpunit -c tests/phpunit.xml --stop-on-failure` *(fails: phpunit not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685c291a3f3c8332956bfdf88bc5c7d0