### PR TITLE
Extend editable field click areas

### DIFF
--- a/assets/js/chasse-edit.js
+++ b/assets/js/chasse-edit.js
@@ -10,6 +10,7 @@ let checkboxIllimitee;
 
 
 document.addEventListener('DOMContentLoaded', () => {
+  if (typeof initZonesClicEdition === 'function') initZonesClicEdition();
   inputDateDebut = document.getElementById('chasse-date-debut');
   inputDateFin = document.getElementById('chasse-date-fin');
   erreurDebut = document.getElementById('erreur-date-debut');

--- a/assets/js/core/champ-init.js
+++ b/assets/js/core/champ-init.js
@@ -405,3 +405,23 @@ function initChampBooleen(bloc) {
     modifierChampSimple(champ, valeur, postId, cpt);
   });
 }
+
+// ==============================
+// 👆 Zone de clic étendue sur l'affichage des champs
+// ==============================
+function initZoneClicEdition(zone) {
+  const bouton = zone.querySelector('.champ-modifier');
+  if (!bouton) return;
+
+  zone.style.cursor = 'pointer';
+
+  zone.addEventListener('click', (e) => {
+    if (e.target.closest('.champ-modifier')) return;
+    bouton.click();
+  });
+}
+
+function initZonesClicEdition() {
+  document.querySelectorAll('.champ-affichage').forEach(initZoneClicEdition);
+}
+window.initZonesClicEdition = initZonesClicEdition;

--- a/assets/js/enigme-edit.js
+++ b/assets/js/enigme-edit.js
@@ -8,6 +8,7 @@ let panneauEdition;
 
 
 document.addEventListener('DOMContentLoaded', () => {
+  if (typeof initZonesClicEdition === 'function') initZonesClicEdition();
   boutonToggle = document.getElementById('toggle-mode-edition-enigme');
   panneauEdition = document.querySelector('.edition-panel-enigme');
 

--- a/assets/js/organisateur-edit.js
+++ b/assets/js/organisateur-edit.js
@@ -2,6 +2,7 @@ var DEBUG = window.DEBUG || false;
 DEBUG && console.log('✅ organisateur-edit.js chargé');
 
 document.addEventListener('DOMContentLoaded', () => {
+  if (typeof initZonesClicEdition === 'function') initZonesClicEdition();
 
   // 🟢 Champs inline
   document.querySelectorAll('.champ-organisateur[data-champ]').forEach((bloc) => {


### PR DESCRIPTION
## Summary
- enable a larger click zone for pencil-editable fields
- hook the new behavior into Chasse, Organisateur and Enigme editors

## Testing
- `phpunit -c tests/phpunit.xml` *(fails: phpunit not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685c432e597483328de0ffcbcb32bf8b