### PR TITLE
Fix status badge missing on hunt page

### DIFF
--- a/template-parts/chasse/chasse-affichage-complet.php
+++ b/template-parts/chasse/chasse-affichage-complet.php
@@ -84,12 +84,10 @@ if ($edition_active && !$est_complet) {
     <?php
     $cache = get_field('champs_caches', $chasse_id);
     $statut = get_field('champs_caches')['chasse_cache_statut'] ?? 'revision';
-    if ($statut !== 'revision') :
     ?>
       <span class="badge-statut statut-<?= esc_attr($statut); ?>" data-post-id="<?= esc_attr($chasse_id); ?>">
         <?= ucfirst(str_replace('_', ' ', $statut)); ?>
       </span>
-    <?php endif; ?>
 
     <!-- 🔧 Bouton panneau édition -->
     <?php if ($edition_active) : ?>


### PR DESCRIPTION
## Summary
- always display the status badge in the single hunt header

## Testing
- `composer install`
- `vendor/bin/phpunit --configuration tests/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_685c48e9be188332a111f545faa48825