### PR TITLE
Ensure resume edit icons open editing panels

### DIFF
--- a/assets/js/core/resume.js
+++ b/assets/js/core/resume.js
@@ -329,5 +329,6 @@ function mettreAJourLigneResume(ligne, champ, estRempli, type) {
     });
 
     ligne.appendChild(bouton);
+    if (typeof initZoneClicEdition === 'function') initZoneClicEdition(bouton);
   }
 }


### PR DESCRIPTION
## Summary
- initialize click zone for completion icons in the résumé panel

## Testing
- `phpunit -c tests/phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_685c610b1f68833287e8ffcde133f1f4