### PR TITLE
Prevent cancel button reopen

### DIFF
--- a/assets/js/core/champ-init.js
+++ b/assets/js/core/champ-init.js
@@ -421,6 +421,8 @@ function initZoneClicEdition(bouton) {
 
     if (
       e.target.closest('.champ-modifier') ||
+      e.target.closest('.champ-annuler') ||
+      e.target.closest('.champ-enregistrer') ||
       e.target.closest('.icone-info') ||
       e.target.closest('input, select, textarea, a')
     ) {


### PR DESCRIPTION
## Summary
- ignore cancel/save buttons in the click zone handler

## Testing
- `composer install`
- `vendor/bin/phpunit --configuration tests/phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_685c6128fc748332a1dd4d9ed5bca9c0