### PR TITLE
Extend resume click area

### DIFF
--- a/assets/css/edition.css
+++ b/assets/css/edition.css
@@ -111,6 +111,12 @@ body.edition-active-enigme .champ-enigme[data-champ] {
   cursor: pointer;
 }
 
+body.edition-active .resume-infos li,
+body.edition-active-chasse .resume-infos li,
+body.edition-active-enigme .resume-infos li {
+  cursor: pointer;
+}
+
 
 /* ========== 📂 Toggle panneau édition ========== */
 section.enigme-wrapper {

--- a/assets/js/core/champ-init.js
+++ b/assets/js/core/champ-init.js
@@ -411,7 +411,7 @@ function initChampBooleen(bloc) {
 // ==============================
 
 function initZoneClicEdition(bouton) {
-  const zone = bouton.closest('[data-champ]');
+  const zone = bouton.closest('li') || bouton.closest('[data-champ]');
   if (!zone) return;
 
 


### PR DESCRIPTION
## Summary
- extend clickable zone in `initZoneClicEdition` to select surrounding list item
- show pointer cursor for resume sections in edition mode

## Testing
- `composer install`
- `vendor/bin/phpunit --configuration tests/phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_685c641a681083329006cac38b60cf3f