### PR TITLE
Fix access rules for draft hunts

### DIFF
--- a/inc/relations-functions.php
+++ b/inc/relations-functions.php
@@ -216,12 +216,18 @@ function organisateur_a_des_chasses($organisateur_id)
   $query = new WP_Query([
     'post_type'      => 'chasse',
     'posts_per_page' => 1,
-    'post_status'    => 'any', // 🔍 Vérifier toutes les chasses, y compris les brouillons
+    'post_status'    => ['publish', 'pending'],
     'meta_query'     => [
+      'relation' => 'AND',
       [
         'key'     => 'champs_caches_chasse_cache_organisateur',
-        'value'   => '"' . $organisateur_id . '"', // 🔄 Ajout de guillemets pour matcher dans un tableau sérialisé
+        'value'   => '"' . $organisateur_id . '"',
         'compare' => 'LIKE'
+      ],
+      [
+        'key'     => 'champs_caches_chasse_cache_statut_validation',
+        'value'   => 'banni',
+        'compare' => '!='
       ]
     ]
   ]);

--- a/inc/statut-functions.php
+++ b/inc/statut-functions.php
@@ -273,16 +273,37 @@ function enigme_verifier_verrouillage(int $enigme_id, int $user_id): array
  */
 function traiter_statut_enigme(int $enigme_id, ?int $user_id = null): array
 {
-    $user_id = $user_id ?: get_current_user_id();
-    $statut = enigme_get_statut_utilisateur($enigme_id, $user_id);
-    $chasse_id = recuperer_id_chasse_associee($enigme_id);
+    $user_id     = $user_id ?: get_current_user_id();
+    $statut       = enigme_get_statut_utilisateur($enigme_id, $user_id);
+    $chasse_id    = recuperer_id_chasse_associee($enigme_id);
+    $post_status  = get_post_status($enigme_id);
 
-    // 🔓 Bypass total : admin ou organisateur
-    // 🛡️ Organisateur ou admin : pas de réponse possible
-    if (
-        current_user_can('manage_options') ||
-        utilisateur_est_organisateur_associe_a_chasse($user_id, $chasse_id)
-    ) {
+    // 🔓 Accès total pour l'administrateur
+    if (current_user_can('manage_options')) {
+        return [
+            'etat' => $statut,
+            'rediriger' => false,
+            'url' => null,
+            'afficher_formulaire' => false,
+            'afficher_message' => false,
+            'message_html' => '',
+        ];
+    }
+
+    // 🚫 Contenu brouillon : aucun accès hors administrateur
+    if ($post_status === 'draft') {
+        return [
+            'etat' => $statut,
+            'rediriger' => true,
+            'url' => $chasse_id ? get_permalink($chasse_id) : home_url('/'),
+            'afficher_formulaire' => false,
+            'afficher_message' => false,
+            'message_html' => '',
+        ];
+    }
+
+    // ✅ Organisateur associé : accès standard
+    if (utilisateur_est_organisateur_associe_a_chasse($user_id, $chasse_id)) {
         return [
             'etat' => $statut,
             'rediriger' => false,


### PR DESCRIPTION
## Summary
- tighten access to draft enigmas so only admins can see them
- ignore banned or draft hunts when counting an organiser's hunts

## Testing
- `npm test` *(fails: package.json missing)*
- `phpunit --configuration tests/phpunit.xml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c64710b6883328a4b808bafafef73