### PR TITLE
Fix missing mapping for immédiat option

### DIFF
--- a/assets/js/enigme-edit.js
+++ b/assets/js/enigme-edit.js
@@ -218,6 +218,7 @@ document.addEventListener('DOMContentLoaded', () => {
   initChampSolution();
   initSolutionInline();
   initChampConditionnel('acf[enigme_acces_condition]', {
+    'immediat': [], // pas d'affichage spécifique pour l'accès immédiat
     'date_programmee': ['#champ-enigme-date'],
     'pre_requis': ['#champ-enigme-pre-requis']
   });


### PR DESCRIPTION
## Summary
- handle "immediat" value when showing conditional puzzle fields

## Testing
- `composer install`
- `vendor/bin/phpunit --configuration tests/phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_685c6643199c8332be77fe2422c65186