### PR TITLE
Synchronize chasse completion on puzzle save

### DIFF
--- a/inc/statut-functions.php
+++ b/inc/statut-functions.php
@@ -640,6 +640,13 @@ function mettre_a_jour_cache_complet_automatiquement($post_id): void
         chasse_mettre_a_jour_complet((int) $post_id);
     } elseif ($type === 'enigme') {
         enigme_mettre_a_jour_complet((int) $post_id);
+
+        // ⚡ Synchronise la chasse parente pour que la complétion soit
+        // immédiatement prise en compte sur la fiche énigme.
+        $chasse_id = recuperer_id_chasse_associee((int) $post_id);
+        if ($chasse_id) {
+            chasse_mettre_a_jour_complet((int) $chasse_id);
+        }
     }
 }
 add_action('acf/save_post', 'mettre_a_jour_cache_complet_automatiquement', 20);


### PR DESCRIPTION
## Summary
- update completion cache when an enigma is saved

## Testing
- `composer install` *(fails: command not found)*
- `vendor/bin/phpunit --configuration tests/phpunit.xml` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_685c6846c4a08332a8a769c5dfa58f96