### PR TITLE
Fix date display in chasse intro section

### DIFF
--- a/assets/js/core/date-fields.js
+++ b/assets/js/core/date-fields.js
@@ -15,10 +15,10 @@ document.addEventListener('DOMContentLoaded', () => {
 function formatDateFr(dateStr) {
   if (!dateStr) return '';
   if (dateStr.includes('T')) {
-    const [datePart, timePart] = dateStr.split('T');
+    const [datePart] = dateStr.split('T');
     const parts = datePart.split('-');
     if (parts.length !== 3) return dateStr;
-    return `${parts[2]}/${parts[1]}/${parts[0]} ${timePart}`;
+    return `${parts[2]}/${parts[1]}/${parts[0]}`;
   }
   const parts = dateStr.split('-');
   if (parts.length !== 3) return dateStr;

--- a/template-parts/chasse/chasse-affichage-complet.php
+++ b/template-parts/chasse/chasse-affichage-complet.php
@@ -147,7 +147,7 @@ if ($edition_active && !$est_complet) {
         <div class="meta-etiquette">
           <?php echo get_svg_icon('calendar'); ?>
           <span class="chasse-date-plage">
-            Du <span class="date-debut"><?= esc_html($date_debut_formatee); ?></span> →
+            <span class="date-debut"><?= esc_html($date_debut_formatee); ?></span> →
             <span class="date-fin"><?= esc_html($date_fin_formatee); ?></span>
           </span>
 


### PR DESCRIPTION
## Summary
- remove `Du` prefix in chasse intro markup
- strip time from JS date formatting function so times aren't shown

## Testing
- `phpunit --configuration tests/phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_685cea4481f08332b970e76fa4225781