### PR TITLE
Fix inconsistent update checks for date fields

### DIFF
--- a/inc/edition/edition-core.php
+++ b/inc/edition/edition-core.php
@@ -511,8 +511,10 @@ function convertir_en_datetime(?string $date_string, array $formats = [
     return null;
   }
 
+  $timezone = function_exists('wp_timezone') ? wp_timezone() : new DateTimeZone('UTC');
+
   foreach ($formats as $format) {
-    $date_obj = DateTime::createFromFormat($format, $date_string);
+    $date_obj = DateTime::createFromFormat($format, $date_string, $timezone);
     if ($date_obj) {
       cat_debug("✅ Date '{$date_string}' convertie avec le format : {$format}");
       return $date_obj;
@@ -521,7 +523,7 @@ function convertir_en_datetime(?string $date_string, array $formats = [
 
   // 🚨 Ajout d'un fallback pour éviter le crash
   cat_debug("⚠️ Échec de conversion pour la date : '{$date_string}'. Formats testés : " . implode(', ', $formats));
-  return new DateTime('now', new DateTimeZone('UTC')); // Retourne la date actuelle au lieu de `null`
+  return null;
 }
 
 /**
@@ -723,10 +725,15 @@ function mettre_a_jour_sous_champ_group(int $post_id, string $group_key_or_name,
   }
 
   $champ_a_enregistrer = [];
+  
+  $sub_field_type = null;
 
   foreach ($group_object['sub_fields'] as $sub_field) {
     $name = $sub_field['name'];
     $type = $sub_field['type'];
+    if ($name === $subfield_name) {
+      $sub_field_type = $type;
+    }
 
     $valeur = $groupe[$name] ?? '';
     if ($name === $subfield_name) {
@@ -758,7 +765,6 @@ function mettre_a_jour_sous_champ_group(int $post_id, string $group_key_or_name,
     $champ_a_enregistrer[$name] = $valeur;
   }
 
-  delete_field($group_object['name'], $post_id);
   cat_debug('[DEBUG] Données envoyées à update_field() pour groupe ' . $group_object['name'] . ' : ' . json_encode($champ_a_enregistrer));
 
   $ok = update_field($group_object['name'], $champ_a_enregistrer, $post_id);
@@ -791,7 +797,15 @@ function mettre_a_jour_sous_champ_group(int $post_id, string $group_key_or_name,
       }
     }
 
-    $str_new = is_array($new_value) ? implode(',', $new_value) : (string) $new_value;
+    if ($sub_field_type === 'date_time_picker') {
+      $dt_new  = convertir_en_datetime((string) $new_value, ['Y-m-d H:i:s', 'Y-m-d\TH:i']);
+      $dt_read = convertir_en_datetime((string) $valeur_relue, ['Y-m-d H:i:s', 'Y-m-d\TH:i']);
+      if ($dt_new && $dt_read) {
+        return $dt_new->getTimestamp() === $dt_read->getTimestamp();
+      }
+    }
+
+    $str_new  = is_array($new_value) ? implode(',', $new_value) : (string) $new_value;
     $str_relue = is_array($valeur_relue) ? implode(',', $valeur_relue) : (string) $valeur_relue;
 
     return wp_strip_all_tags($str_new) === wp_strip_all_tags($str_relue);


### PR DESCRIPTION
## Summary
- compare timestamps for date_time_picker fields using proper timezone
- avoid deleting the ACF group before updates
- ensure `convertir_en_datetime` honors WP timezone

## Testing
- `composer install` *(fails: command not found)*
- `vendor/bin/phpunit --configuration tests/phpunit.xml` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_685cefe49d88833291bec932dbfc1bac