### PR TITLE
Improve hunt date update handling

### DIFF
--- a/assets/js/core/date-fields.js
+++ b/assets/js/core/date-fields.js
@@ -94,16 +94,33 @@ function initChampDate(input) {
       }
     }
 
-    modifierChampSimple(champ, valeur, postId, cpt).then(success => {
-      if (success) {
-        input.dataset.previous = valeurBrute;
-        if (typeof window.onDateFieldUpdated === 'function') {
-          window.onDateFieldUpdated(input, valeurBrute);
+    if (
+      cpt === 'chasse' &&
+      typeof window.enregistrerDatesChasse === 'function' &&
+      (champ.endsWith('_date_debut') || champ.endsWith('_date_fin'))
+    ) {
+      window.enregistrerDatesChasse().then(success => {
+        if (success) {
+          input.dataset.previous = valeurBrute;
+          if (typeof window.onDateFieldUpdated === 'function') {
+            window.onDateFieldUpdated(input, valeurBrute);
+          }
+        } else {
+          input.value = input.dataset.previous || '';
         }
-      } else {
-        input.value = input.dataset.previous || '';
-      }
-    });
+      });
+    } else {
+      modifierChampSimple(champ, valeur, postId, cpt).then(success => {
+        if (success) {
+          input.dataset.previous = valeurBrute;
+          if (typeof window.onDateFieldUpdated === 'function') {
+            window.onDateFieldUpdated(input, valeurBrute);
+          }
+        } else {
+          input.value = input.dataset.previous || '';
+        }
+      });
+    }
   };
 
   input.addEventListener('change', enregistrer);


### PR DESCRIPTION
## Summary
- add new AJAX handler to update start, end and unlimited dates in one request
- update date field JS to call the new handler
- use new function in hunt edit script when changing the unlimited checkbox

## Testing
- `vendor/bin/phpunit --configuration tests/phpunit.xml` *(fails: `No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_685d02549960833293577e4cbea2f7e1