### PR TITLE
Display chasse links banner

### DIFF
--- a/assets/css/chasse.css
+++ b/assets/css/chasse.css
@@ -77,6 +77,35 @@
     margin-bottom: 0;
 }
 
+/* Bandeau discret en bas à droite avec les liens publics */
+.chasse-section-intro {
+    position: relative;
+}
+.chasse-section-intro .bandeau-liens-chasse {
+    position: absolute;
+    right: 0.5rem;
+    bottom: 0.5rem;
+    background: rgba(0, 0, 0, 0.6);
+    padding: 0.25rem 0.5rem;
+    border-radius: 0.5rem;
+    z-index: 10;
+}
+.chasse-section-intro .bandeau-liens-chasse .liste-liens-publics {
+    gap: 0.5rem;
+}
+.chasse-section-intro .bandeau-liens-chasse .lien-public {
+    padding: 0;
+    background: none;
+    color: #fff;
+    font-size: 1.2rem;
+}
+.chasse-section-intro .bandeau-liens-chasse .lien-public:hover {
+    color: var(--color-secondary);
+}
+.chasse-section-intro .bandeau-liens-chasse .texte-lien {
+    display: none;
+}
+
 .chasse-section-intro.champ-vide-obligatoire {
     border: 2px dashed var(--color-editor-error);
     animation: clignoteTitre 1s infinite alternate;

--- a/template-parts/chasse/chasse-affichage-complet.php
+++ b/template-parts/chasse/chasse-affichage-complet.php
@@ -55,6 +55,21 @@ $edition_active = utilisateur_peut_modifier_post($chasse_id);
 $organisateur_id = get_organisateur_from_chasse($chasse_id);
 $organisateur_nom = $organisateur_id ? get_the_title($organisateur_id) : get_the_author();
 
+// Liens publics de la chasse
+$liens_publics = get_field('chasse_principale_liens', $chasse_id);
+$liens_publics = is_array($liens_publics) ? $liens_publics : [];
+$has_liens = false;
+foreach ($liens_publics as $entry) {
+    $url = $entry['chasse_principale_liens_url'] ?? '';
+    if (is_string($url) && trim($url) !== '') {
+        $has_liens = true;
+        break;
+    }
+}
+$liens_publics_html = $has_liens
+    ? render_liens_publics($liens_publics, 'chasse', ['afficher_titre' => false, 'wrap' => false])
+    : '';
+
 
 if (current_user_can('administrator')) {
   $chasse_id = get_the_ID();
@@ -195,6 +210,11 @@ if ($edition_active && !$est_complet) {
 
     </div>
   </div>
+  <?php if ($liens_publics_html) : ?>
+    <div class="bandeau-liens-chasse">
+      <?= $liens_publics_html; ?>
+    </div>
+  <?php endif; ?>
 </section>
 
 <?php if ($edition_active) : ?>


### PR DESCRIPTION
## Summary
- add banner for hunt public links in chasse intro
- style banner in chasse.css

## Testing
- `composer install`
- `vendor/bin/phpunit --configuration tests/phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_685d143eb35883329ff8e2d2f739f091