### PR TITLE
Improve logging for date updates

### DIFF
--- a/assets/js/chasse-edit.js
+++ b/assets/js/chasse-edit.js
@@ -312,6 +312,7 @@ function initLiensChasse(bloc) {
 // 🔎 Validation logique entre date de début et date de fin
 // ==============================
 function validerDatesAvantEnvoi(champModifie) {
+  console.log('[validerDatesAvantEnvoi] champModifie=', champModifie);
   // ✅ Si illimité, on n'applique aucun contrôle
   if (checkboxIllimitee?.checked) return true;
 
@@ -379,6 +380,7 @@ function validerDatesAvantEnvoi(champModifie) {
 // 🔥 Affichage d'un message global temporaire
 // ==============================
 function afficherErreurGlobale(message) {
+  console.log('[afficherErreurGlobale]', message);
   const erreurGlobal = document.getElementById('erreur-global');
   if (!erreurGlobal) return;
 
@@ -611,6 +613,7 @@ document.addEventListener('acf/submit_success', function (e) {
 // 🔁 Rafraîchissement dynamique du statut de la chasse
 // ================================
 function rafraichirStatutChasse(postId) {
+  console.log('[rafraichirStatutChasse] postId=', postId);
   if (!postId) return;
 
   fetch(ajaxurl, {
@@ -667,6 +670,7 @@ function rafraichirStatutChasse(postId) {
 // 💾 Enregistrement groupé des dates de chasse
 // ================================
 function enregistrerDatesChasse() {
+  console.log('[enregistrerDatesChasse]');
   if (!inputDateDebut || !inputDateFin) return Promise.resolve(false);
 
   const postId = inputDateDebut.closest('.champ-chasse')?.dataset.postId;

--- a/assets/js/core/champ-date-hooks.js
+++ b/assets/js/core/champ-date-hooks.js
@@ -3,6 +3,7 @@
 var DEBUG = window.DEBUG || false;
 
 window.onDateFieldUpdated = function(input, valeur) {
+  console.log('[onDateFieldUpdated]', input, valeur);
   const champ = input.closest('[data-champ]')?.dataset.champ;
   if (!champ) return;
 

--- a/assets/js/core/date-fields.js
+++ b/assets/js/core/date-fields.js
@@ -13,6 +13,7 @@ document.addEventListener('DOMContentLoaded', () => {
 // 📅 Formatage des dates Y-m-d ➔ d/m/Y
 // ==============================
 function formatDateFr(dateStr) {
+  console.log('[formatDateFr] input=', dateStr);
   if (!dateStr) return '';
   if (dateStr.includes('T')) {
     const [datePart] = dateStr.split('T');
@@ -31,6 +32,7 @@ function formatDateFr(dateStr) {
 // 📅 Mise à jour affichage Date Fin
 // ==============================
 function mettreAJourAffichageDateFin() {
+  console.log('[mettreAJourAffichageDateFin]');
   const spanDateFin = document.querySelector('.chasse-date-plage .date-fin');
   const inputDateFin = document.getElementById('chasse-date-fin');
   const checkboxIllimitee = document.getElementById('duree-illimitee');

--- a/inc/edition/edition-chasse.php
+++ b/inc/edition/edition-chasse.php
@@ -188,6 +188,8 @@ function modifier_dates_chasse()
   $date_fin    = sanitize_text_field($_POST['date_fin'] ?? '');
   $illimitee   = isset($_POST['illimitee']) ? (int) $_POST['illimitee'] : 0;
 
+  error_log("[modifier_dates_chasse] post_id={$post_id} date_debut={$date_debut} date_fin={$date_fin} illimitee={$illimitee}");
+
   if (!$post_id || get_post_type($post_id) !== 'chasse') {
     wp_send_json_error('post_invalide');
   }
@@ -210,6 +212,7 @@ function modifier_dates_chasse()
   if (!$dt_debut) {
     wp_send_json_error('format_debut_invalide');
   }
+  error_log('[modifier_dates_chasse] dt_debut=' . $dt_debut->format('c'));
 
   $dt_fin = null;
   if (!$illimitee) {
@@ -224,6 +227,7 @@ function modifier_dates_chasse()
     if ($dt_fin->getTimestamp() <= $dt_debut->getTimestamp()) {
       wp_send_json_error('date_fin_avant_debut');
     }
+    error_log('[modifier_dates_chasse] dt_fin=' . $dt_fin->format('c'));
   }
 
   mettre_a_jour_sous_champ_group(
@@ -244,6 +248,7 @@ function modifier_dates_chasse()
     'chasse_infos_date_debut',
     $dt_debut->format('Y-m-d H:i:s')
   );
+  error_log('[modifier_dates_chasse] update chasse_infos_date_debut=' . var_export($ok1, true));
 
   $ok2 = mettre_a_jour_sous_champ_group(
     $post_id,
@@ -251,6 +256,7 @@ function modifier_dates_chasse()
     'chasse_infos_duree_illimitee',
     $illimitee ? 1 : 0
   );
+  error_log('[modifier_dates_chasse] update chasse_infos_duree_illimitee=' . var_export($ok2, true));
 
   $ok3 = mettre_a_jour_sous_champ_group(
     $post_id,
@@ -258,9 +264,11 @@ function modifier_dates_chasse()
     'chasse_infos_date_fin',
     $illimitee ? '' : $dt_fin->format('Y-m-d')
   );
+  error_log('[modifier_dates_chasse] update chasse_infos_date_fin=' . var_export($ok3, true));
 
   if ($ok1 && $ok2 && $ok3) {
     mettre_a_jour_statuts_chasse($post_id);
+    error_log('[modifier_dates_chasse] mise a jour reussie');
     wp_send_json_success([
       'date_debut' => $dt_debut->format('Y-m-d H:i:s'),
       'date_fin'   => $illimitee ? '' : $dt_fin->format('Y-m-d'),
@@ -268,6 +276,7 @@ function modifier_dates_chasse()
     ]);
   }
 
+  error_log('[modifier_dates_chasse] echec mise a jour');
   wp_send_json_error('echec_mise_a_jour');
 }
 


### PR DESCRIPTION
## Summary
- emit more PHP `error_log` messages during date update operations
- add console debugging in date-related JavaScript functions

## Testing
- `composer install` *(fails: command not found)*
- `./vendor/bin/phpunit --configuration tests/phpunit.xml` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_685d2f35fae08332bb29fef17d9cdc26