### PR TITLE
Improve local setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,28 @@ This repository contains the custom WordPress theme used on **chassesautresor.co
 
 ## Setup
 
-Install PHP dependencies and run the test suite from the repository root:
+The theme targets **PHP 8.1+** and requires the extensions `pdo_mysql`,
+`mbstring`, `gd` and `xml`. On Debian/Ubuntu systems these can be installed via:
+
+```bash
+sudo apt-get install php php-mysql php-mbstring php-gd php-xml
+```
+
+If Composer is not installed, run the helper script provided in `scripts/`:
+
+```bash
+./scripts/install-composer.sh
+```
+
+Once the prerequisites are available, fetch dependencies and execute the tests
+from the repository root:
 
 ```bash
 composer install
 vendor/bin/phpunit --configuration tests/phpunit.xml
 ```
+
+You can alternatively work inside Docker by launching `docker-compose up` and
+running the same Composer and PHPUnit commands in the `web` container.
 
 More details about the theme development workflow are available in the [docs/](docs/) directory.

--- a/scripts/install-composer.sh
+++ b/scripts/install-composer.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# Simple script to install Composer globally for the current user on Debian/Ubuntu systems.
+set -e
+php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
+php composer-setup.php --install-dir=/usr/local/bin --filename=composer
+php -r "unlink('composer-setup.php');"


### PR DESCRIPTION
## Summary
- document required PHP extensions
- add a helper script for installing Composer

## Testing
- `bash scripts/install-composer.sh` *(fails: network unreachable)*
- `vendor/bin/phpunit --configuration tests/phpunit.xml` *(fails: no such file)*

------
https://chatgpt.com/codex/tasks/task_e_685d4e88ab288332ade29985bce9427b