### PR TITLE
Add tests for group subfield updates

### DIFF
--- a/tests/EditionCoreGroupTest.php
+++ b/tests/EditionCoreGroupTest.php
@@ -1,0 +1,78 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/bootstrap.php';
+
+class EditionCoreGroupTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        global $mock_fields, $mock_field_objects;
+        $mock_fields = [];
+        $mock_field_objects = [];
+    }
+
+    public function test_update_datetime_picker_by_name()
+    {
+        global $mock_fields, $mock_field_objects;
+        $post_id = 1;
+
+        $group_object = [
+            'name' => 'caracteristiques',
+            'sub_fields' => [
+                [
+                    'name' => 'chasse_infos_date_debut',
+                    'key'  => 'field_date_debut',
+                    'type' => 'date_time_picker',
+                ],
+            ],
+        ];
+        $mock_field_objects['group_carac'] = $group_object;
+        $mock_field_objects['caracteristiques'] = $group_object;
+
+        $result = mettre_a_jour_sous_champ_group(
+            $post_id,
+            'caracteristiques',
+            'chasse_infos_date_debut',
+            '2025-06-01'
+        );
+
+        $this->assertTrue($result);
+        $this->assertSame('2025-06-01 00:00:00', $mock_fields[$post_id]['caracteristiques']['chasse_infos_date_debut']);
+    }
+
+    public function test_grouped_updates_store_values()
+    {
+        global $mock_fields, $mock_field_objects;
+        $post_id = 2;
+
+        $group_object = [
+            'name' => 'infos',
+            'sub_fields' => [
+                [
+                    'name' => 'infos_titre',
+                    'key'  => 'field_titre',
+                    'type' => 'text',
+                ],
+                [
+                    'name' => 'infos_date',
+                    'key'  => 'field_date',
+                    'type' => 'date_time_picker',
+                ],
+            ],
+        ];
+        $mock_field_objects['group_infos'] = $group_object;
+        $mock_field_objects['infos'] = $group_object;
+
+        $values = [
+            'infos_titre' => 'Test',
+            'infos_date'  => '2025-05-01 10:30:00',
+        ];
+
+        $result = mettre_a_jour_sous_champ_group($post_id, 'infos', '', $values);
+
+        $this->assertTrue($result);
+        $this->assertSame('Test', $mock_fields[$post_id]['infos']['infos_titre']);
+        $this->assertSame('2025-05-01 10:30:00', $mock_fields[$post_id]['infos']['infos_date']);
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -17,7 +17,39 @@ if (!function_exists('add_rewrite_rule')) {
 
 $mock_posts = [];
 $mock_fields = [];
+$mock_field_objects = [];
 $mock_current_time = null;
+
+if (!function_exists('update_field')) {
+    function update_field($selector, $value, $post_id = false) {
+        global $mock_fields;
+        $mock_fields[$post_id][$selector] = $value;
+        return true;
+    }
+}
+if (!function_exists('get_field_object')) {
+    function get_field_object($selector, $post_id = false) {
+        global $mock_field_objects;
+        if (isset($mock_field_objects[$selector])) {
+            return $mock_field_objects[$selector];
+        }
+        foreach ($mock_field_objects as $object) {
+            if (($object['name'] ?? null) === $selector) {
+                return $object;
+            }
+        }
+        return null;
+    }
+}
+if (!function_exists('clean_post_cache')) {
+    function clean_post_cache($post_id) {}
+}
+if (!function_exists('wp_strip_all_tags')) {
+    function wp_strip_all_tags($string) { return strip_tags($string); }
+}
+if (!function_exists('cat_debug')) {
+    function cat_debug($message, bool $force = false): void {}
+}
 
 // Minimal WP user functions for tests
 $mock_users = [];
@@ -156,3 +188,4 @@ require_once __DIR__ . '/../inc/constants.php';
 require_once __DIR__ . '/../inc/access-functions.php';
 require_once __DIR__ . '/../inc/chasse-functions.php';
 require_once __DIR__ . '/../inc/user-functions.php';
+require_once __DIR__ . '/../inc/edition/edition-core.php';


### PR DESCRIPTION
## Summary
- add EditionCoreGroupTest verifying mettre_a_jour_sous_champ_group()
- stub ACF helpers in bootstrap and load edition-core

## Testing
- `phpunit -c tests/phpunit.xml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d4e8268b48332b2565a4f2cc3e8bd