### PR TITLE
Refactor ACF grouped fields

### DIFF
--- a/inc/access-functions.php
+++ b/inc/access-functions.php
@@ -298,8 +298,8 @@ function utilisateur_peut_creer_post($post_type, $chasse_id = null)
             }
 
             // ✅ Vérifier que la chasse est en "création"
-            $champs_caches = get_field('champs_caches', $chasse_id);
-            return trim($champs_caches['statut_validation'] ?? '') === 'creation';
+            $validation = get_field('champs_caches_chasse_cache_statut_validation', $chasse_id);
+            return trim($validation ?? '') === 'creation';
     }
 
     return false;
@@ -403,8 +403,7 @@ function utilisateur_peut_voir_enigme(int $enigme_id, ?int $user_id = null): boo
 
     // ✅ Exception organisateur : accès si chasse en création, correction
     //    ou en attente de validation
-    $champs_caches = get_field('champs_caches', $chasse_id);
-    $statut_validation = $champs_caches['chasse_cache_statut_validation'] ?? null;
+    $statut_validation = get_field('champs_caches_chasse_cache_statut_validation', $chasse_id);
     error_log("🧪 [voir énigme] chasse #$chasse_id → statut_validation = $statut_validation");
 
     if (in_array($statut_validation, ['creation', 'correction', 'en_attente'], true)) {
@@ -450,9 +449,8 @@ function utilisateur_peut_ajouter_enigme(int $chasse_id, ?int $user_id = null): 
         return false;
     }
 
-    $cache = get_field('champs_caches', $chasse_id);
-    $statut_validation = $cache['chasse_cache_statut_validation'] ?? null;
-    $statut_metier     = $cache['chasse_cache_statut'] ?? null;
+    $statut_validation = get_field('champs_caches_chasse_cache_statut_validation', $chasse_id);
+    $statut_metier     = get_field('champs_caches_chasse_cache_statut', $chasse_id);
 
     if ($statut_metier !== 'revision') {
         error_log("❌ [ajout énigme] chasse #$chasse_id statut metier : $statut_metier");
@@ -503,8 +501,7 @@ function utilisateur_peut_modifier_enigme(int $enigme_id, ?int $user_id = null):
     if (!$chasse_id || get_post_type($chasse_id) !== 'chasse') return false;
 
     // Récupérer l'état de validation de la chasse
-    $champs_caches = get_field('champs_caches', $chasse_id);
-    $statut_validation = $champs_caches['chasse_cache_statut_validation'] ?? null;
+    $statut_validation = get_field('champs_caches_chasse_cache_statut_validation', $chasse_id);
 
 
     // L'utilisateur doit être associé à l'organisateur de la chasse
@@ -542,9 +539,8 @@ function utilisateur_peut_supprimer_enigme(int $enigme_id, ?int $user_id = null)
         return false;
     }
 
-    $cache = get_field('champs_caches', $chasse_id);
-    $statut_validation = $cache['chasse_cache_statut_validation'] ?? null;
-    $statut_metier     = $cache['chasse_cache_statut'] ?? null;
+    $statut_validation = get_field('champs_caches_chasse_cache_statut_validation', $chasse_id);
+    $statut_metier     = get_field('champs_caches_chasse_cache_statut', $chasse_id);
 
     if ($statut_metier !== 'revision') {
         return false;
@@ -630,8 +626,7 @@ function utilisateur_peut_voir_panneau(int $post_id): bool
             return in_array($status, ['publish', 'pending'], true);
 
         case 'chasse':
-            $cache = get_field('champs_caches', $post_id);
-            $val   = $cache['chasse_cache_statut_validation'] ?? '';
+            $val = get_field('champs_caches_chasse_cache_statut_validation', $post_id) ?? '';
 
             return in_array($status, ['publish', 'pending'], true) && $val !== 'banni';
 
@@ -670,9 +665,9 @@ function utilisateur_peut_editer_champs(int $post_id): bool
             return in_array(ROLE_ORGANISATEUR_CREATION, $roles, true) && $status === 'pending';
 
         case 'chasse':
-            $cache   = get_field('champs_caches', $post_id);
-            $val     = $cache['chasse_cache_statut_validation'] ?? '';
-            $stat    = $cache['chasse_cache_statut'] ?? '';
+            $val     = get_field('champs_caches_chasse_cache_statut_validation', $post_id) ?? '';
+            $stat    = get_field('champs_caches_chasse_cache_statut', $post_id) ?? '';
+            $complet = (bool) get_field('chasse_cache_complet', $post_id);
             $complet = (bool) get_field('chasse_cache_complet', $post_id);
 
             // Les organisateurs en cours de création peuvent éditer toute chasse
@@ -692,9 +687,8 @@ function utilisateur_peut_editer_champs(int $post_id): bool
             }
 
             $chasse_status = get_post_status($chasse_id);
-            $cache         = get_field('champs_caches', $chasse_id);
-            $val           = $cache['chasse_cache_statut_validation'] ?? '';
-            $stat          = $cache['chasse_cache_statut'] ?? '';
+            $val           = get_field('champs_caches_chasse_cache_statut_validation', $chasse_id) ?? '';
+            $stat          = get_field('champs_caches_chasse_cache_statut', $chasse_id) ?? '';
             $etat          = get_field('enigme_cache_etat_systeme', $post_id);
 
             return $chasse_status === 'pending'
@@ -1141,8 +1135,7 @@ function chasse_est_visible_pour_utilisateur(int $chasse_id, int $user_id): bool
         return false;
     }
 
-    $cache      = get_field('champs_caches', $chasse_id) ?: [];
-    $validation = $cache['chasse_cache_statut_validation'] ?? '';
+    $validation = get_field('champs_caches_chasse_cache_statut_validation', $chasse_id) ?? '';
 
     if ($status === 'pending') {
         $assoc = utilisateur_est_organisateur_associe_a_chasse($user_id, $chasse_id);

--- a/inc/chasse-functions.php
+++ b/inc/chasse-functions.php
@@ -45,20 +45,17 @@ function recuperer_infos_chasse($chasse_id) {
  * @return array
  */
 function chasse_get_champs($chasse_id) {
-    $caracteristiques = get_field('caracteristiques', $chasse_id) ?? [];
-    $champs_caches = get_field('champs_caches', $chasse_id) ?? [];
-
     return [
-        'lot' => $caracteristiques['chasse_infos_recompense_texte'] ?? '',
-        'titre_recompense' => $caracteristiques['chasse_infos_recompense_titre'] ?? '',
-        'valeur_recompense' => $caracteristiques['chasse_infos_recompense_valeur'] ?? '',
-        'cout_points' => $caracteristiques['chasse_infos_cout_points'] ?? 0,
-        'date_debut' => $caracteristiques['chasse_infos_date_debut'] ?? null,
-        'date_fin' => $caracteristiques['chasse_infos_date_fin'] ?? null,
-        'illimitee' => $caracteristiques['chasse_infos_duree_illimitee'] ?? false,
-        'nb_max' => $caracteristiques['chasse_infos_nb_max_gagants'] ?? 0,
-        'date_decouverte' => $champs_caches['chasse_cache_date_decouverte'] ?? null,
-        'current_stored_statut' => $champs_caches['chasse_cache_statut'] ?? null,
+        'lot' => get_field('chasse_infos_recompense_texte', $chasse_id) ?? '',
+        'titre_recompense' => get_field('chasse_infos_recompense_titre', $chasse_id) ?? '',
+        'valeur_recompense' => get_field('chasse_infos_recompense_valeur', $chasse_id) ?? '',
+        'cout_points' => get_field('chasse_infos_cout_points', $chasse_id) ?? 0,
+        'date_debut' => get_field('chasse_infos_date_debut', $chasse_id),
+        'date_fin' => get_field('chasse_infos_date_fin', $chasse_id),
+        'illimitee' => get_field('chasse_infos_duree_illimitee', $chasse_id) ?? false,
+        'nb_max' => get_field('chasse_infos_nb_max_gagants', $chasse_id) ?? 0,
+        'date_decouverte' => get_field('champs_caches_chasse_cache_date_decouverte', $chasse_id),
+        'current_stored_statut' => get_field('champs_caches_chasse_cache_statut', $chasse_id),
     ];
 }
 
@@ -313,16 +310,14 @@ function peut_valider_chasse(int $chasse_id, int $user_id): bool
         return false;
     }
 
-    $cache = get_field('champs_caches', $chasse_id);
-    if (!$cache) {
+    $statut_validation = get_field('champs_caches_chasse_cache_statut_validation', $chasse_id);
+    $statut_metier     = get_field('champs_caches_chasse_cache_statut', $chasse_id);
+
+    if (!in_array($statut_validation ?? '', ['creation', 'correction'], true)) {
         return false;
     }
 
-    if (!in_array($cache['chasse_cache_statut_validation'] ?? '', ['creation', 'correction'], true)) {
-        return false;
-    }
-
-    if (($cache['chasse_cache_statut'] ?? '') !== 'revision') {
+    if (($statut_metier ?? '') !== 'revision') {
         return false;
     }
 
@@ -424,8 +419,7 @@ function solution_peut_etre_affichee(int $enigme_id): bool
     if ($mode === 'delai_fin_chasse') {
         $base = get_field('date_de_decouverte', $chasse_id);
         if (!$base) {
-            $carac = get_field('caracteristiques', $chasse_id);
-            $base  = $carac['chasse_infos_date_fin'] ?? null;
+            $base = get_field('chasse_infos_date_fin', $chasse_id);
         }
         $timestamp_base = $base ? strtotime($base) : $now;
         $cible = strtotime("+$delai days $heure", $timestamp_base);

--- a/inc/edition/edition-chasse.php
+++ b/inc/edition/edition-chasse.php
@@ -132,30 +132,14 @@ function creer_chasse_et_rediriger_si_appel()
   $today = current_time('Y-m-d H:i:s');
   $in_two_years = date('Y-m-d', strtotime('+2 years'));
 
-  // ✅ Initialisation des groupes ACF
-  mettre_a_jour_sous_champ_group(
-    $post_id,
-    'caracteristiques',
-    'chasse_infos_date_debut',
-    $today,
-    [
-      'chasse_infos_date_debut'      => $today,
-      'chasse_infos_date_fin'        => $in_two_years,
-      'chasse_infos_duree_illimitee' => false,
-    ]
-  );
+  // ✅ Initialisation des champs ACF
+  update_field('chasse_infos_date_debut', $today, $post_id);
+  update_field('chasse_infos_date_fin', $in_two_years, $post_id);
+  update_field('chasse_infos_duree_illimitee', false, $post_id);
 
-  mettre_a_jour_sous_champ_group(
-    $post_id,
-    'champs_caches',
-    'chasse_cache_organisateur',
-    [$organisateur_id],
-    [
-      'chasse_cache_statut'            => 'revision',
-      'chasse_cache_statut_validation' => 'creation',
-      'chasse_cache_organisateur'      => [$organisateur_id],
-    ]
-  );
+  update_field('champs_caches_chasse_cache_statut', 'revision', $post_id);
+  update_field('champs_caches_chasse_cache_statut_validation', 'creation', $post_id);
+  update_field('champs_caches_chasse_cache_organisateur', [$organisateur_id], $post_id);
 
   // 🚀 Redirection vers la prévisualisation frontale avec panneau ouvert
   $preview_url = add_query_arg('edition', 'open', get_preview_post_link($post_id));
@@ -230,40 +214,13 @@ function modifier_dates_chasse()
     error_log('[modifier_dates_chasse] dt_fin=' . $dt_fin->format('c'));
   }
 
-  mettre_a_jour_sous_champ_group(
-    $post_id,
-    'caracteristiques',
-    '',
-    [],
-    [
-      'chasse_infos_date_debut'      => '',
-      'chasse_infos_date_fin'        => '',
-      'chasse_infos_duree_illimitee' => 0,
-    ]
-  );
-
-  $ok1 = mettre_a_jour_sous_champ_group(
-    $post_id,
-    'caracteristiques',
-    'chasse_infos_date_debut',
-    $dt_debut->format('Y-m-d H:i:s')
-  );
+  $ok1 = update_field('chasse_infos_date_debut', $dt_debut->format('Y-m-d H:i:s'), $post_id);
   error_log('[modifier_dates_chasse] update chasse_infos_date_debut=' . var_export($ok1, true));
 
-  $ok2 = mettre_a_jour_sous_champ_group(
-    $post_id,
-    'caracteristiques',
-    'chasse_infos_duree_illimitee',
-    $illimitee ? 1 : 0
-  );
+  $ok2 = update_field('chasse_infos_duree_illimitee', $illimitee ? 1 : 0, $post_id);
   error_log('[modifier_dates_chasse] update chasse_infos_duree_illimitee=' . var_export($ok2, true));
 
-  $ok3 = mettre_a_jour_sous_champ_group(
-    $post_id,
-    'caracteristiques',
-    'chasse_infos_date_fin',
-    $illimitee ? '' : $dt_fin->format('Y-m-d')
-  );
+  $ok3 = update_field('chasse_infos_date_fin', $illimitee ? '' : $dt_fin->format('Y-m-d'), $post_id);
   error_log('[modifier_dates_chasse] update chasse_infos_date_fin=' . var_export($ok3, true));
 
   if ($ok1 && $ok2 && $ok3) {
@@ -327,23 +284,7 @@ function modifier_champ_chasse()
   $doit_recalculer_statut = false;
   $champ_valide = false;
   $reponse = ['champ' => $champ, 'valeur' => $valeur];
-  // 🛡️ Initialisation sécurisée du groupe caracteristiques
-  mettre_a_jour_sous_champ_group(
-    $post_id,
-    'caracteristiques',
-    '',
-    [],
-    [
-      'chasse_infos_date_debut'        => '',
-      'chasse_infos_date_fin'          => '',
-      'chasse_infos_duree_illimitee'   => 0,
-      'chasse_infos_recompense_valeur' => '',
-      'chasse_infos_recompense_titre'  => '',
-      'chasse_infos_recompense_texte'  => '',
-      'chasse_infos_nb_max_gagants'    => 0,
-      'chasse_infos_cout_points'       => 0,
-    ]
-  );
+  // 🛡️ Initialisation sécurisée (champ simple)
 
 
   // 🔹 post_title
@@ -386,9 +327,8 @@ function modifier_champ_chasse()
       wp_send_json_error('⚠️ format_date_invalide');
     }
     $valeur = $dt->format('Y-m-d H:i:s');
-
-    $ok = mettre_a_jour_sous_champ_group($post_id, 'caracteristiques', 'chasse_infos_date_debut', $valeur);
-    if ($ok) {
+    $ok = update_field('chasse_infos_date_debut', $valeur, $post_id);
+    if ($ok !== false) {
       $champ_valide = true;
       $doit_recalculer_statut = true;
     }
@@ -398,8 +338,8 @@ function modifier_champ_chasse()
     if (!preg_match('/^\d{4}-\d{2}-\d{2}$/', $valeur)) {
       wp_send_json_error('⚠️ format_date_invalide');
     }
-    $ok = mettre_a_jour_sous_champ_group($post_id, 'caracteristiques', 'chasse_infos_date_fin', $valeur);
-    if ($ok) {
+    $ok = update_field('chasse_infos_date_fin', $valeur, $post_id);
+    if ($ok !== false) {
       $champ_valide = true;
       $doit_recalculer_statut = true;
     }
@@ -407,15 +347,12 @@ function modifier_champ_chasse()
 
   // 🔹 Durée illimitée (true_false)
   if ($champ === 'caracteristiques.chasse_infos_duree_illimitee') {
-    $groupe = get_field('caracteristiques', $post_id) ?: [];
-    $groupe['chasse_infos_duree_illimitee'] = (int) $valeur;
-    $ok = update_field('caracteristiques', $groupe, $post_id);
-    $carac_maj = get_field('caracteristiques', $post_id);
-    $mode_continue = empty($carac_maj['chasse_infos_duree_illimitee']);
-    cat_debug("🧪 Illimitée (après MAJ) = " . var_export($carac_maj['chasse_infos_duree_illimitee'], true));
+    $ok = update_field('chasse_infos_duree_illimitee', (int) $valeur, $post_id);
+    $mode_continue = empty(get_field('chasse_infos_duree_illimitee', $post_id));
+    cat_debug("🧪 Illimitée (après MAJ) = " . var_export(!$mode_continue, true));
 
 
-    if ($ok) {
+    if ($ok !== false) {
       $champ_valide = true;
       $doit_recalculer_statut = true;
     }
@@ -428,15 +365,15 @@ function modifier_champ_chasse()
   ];
   if (in_array($champ, $champs_recompense, true)) {
     $sous_champ = str_replace('caracteristiques.', '', $champ);
-    $ok = mettre_a_jour_sous_champ_group($post_id, 'caracteristiques', $sous_champ, $valeur);
-    if ($ok) $champ_valide = true;
+    $ok = update_field($sous_champ, $valeur, $post_id);
+    if ($ok !== false) $champ_valide = true;
     $doit_recalculer_statut = true;
   }
 
   if ($champ === 'caracteristiques.chasse_infos_cout_points') {
     cat_debug("🧪 Correction tentative : MAJ cout_points → valeur = {$valeur}");
-    $ok = mettre_a_jour_sous_champ_group($post_id, 'caracteristiques', 'chasse_infos_cout_points', (int) $valeur);
-    if ($ok) {
+    $ok = update_field('chasse_infos_cout_points', (int) $valeur, $post_id);
+    if ($ok !== false) {
       cat_debug("✅ MAJ réussie pour chasse_infos_cout_points");
       $champ_valide = true;
       $doit_recalculer_statut = true;
@@ -461,23 +398,21 @@ function modifier_champ_chasse()
   // 🔹 Nb gagnants
   if ($champ === 'caracteristiques.chasse_infos_nb_max_gagants') {
     $sous_champ = 'chasse_infos_nb_max_gagants';
-    $ok = mettre_a_jour_sous_champ_group($post_id, 'caracteristiques', $sous_champ, (int) $valeur);
-    if ($ok) $champ_valide = true;
+    $ok = update_field($sous_champ, (int) $valeur, $post_id);
+    if ($ok !== false) $champ_valide = true;
   }
 
   // 🔹 Titre récompense
   if ($champ === 'caracteristiques.chasse_infos_recompense_titre') {
     $sous_champ = 'chasse_infos_recompense_titre';
-    $ok = mettre_a_jour_sous_champ_group($post_id, 'caracteristiques', $sous_champ, $valeur);
-    if ($ok) $champ_valide = true;
+    $ok = update_field($sous_champ, $valeur, $post_id);
+    if ($ok !== false) $champ_valide = true;
   }
 
   // 🔹 Validation manuelle (par admin)
   if ($champ === 'champs_caches.chasse_cache_statut_validation' || $champ === 'chasse_cache_statut_validation') {
-    $ok = update_field('champs_caches', array_merge(get_field('champs_caches', $post_id), [
-      'chasse_cache_statut_validation' => sanitize_text_field($valeur)
-    ]), $post_id);
-    if ($ok) $champ_valide = true;
+    $ok = update_field('champs_caches_chasse_cache_statut_validation', sanitize_text_field($valeur), $post_id);
+    if ($ok !== false) $champ_valide = true;
   }
 
   // 🔹 Cas générique (fallback)
@@ -507,7 +442,7 @@ function modifier_champ_chasse()
   if ($doit_recalculer_statut || in_array($champ, $champs_declencheurs_statut, true)) {
     wp_cache_delete($post_id, 'post');
     sleep(1); // donne une chance au cache + update ACF de se stabiliser
-    $caracteristiques = get_field('caracteristiques', $post_id);
+    $caracteristiques = get_field('chasse_infos_date_debut', $post_id);
     cat_debug("[🔁 RELOAD] Relecture avant recalcul : " . json_encode($caracteristiques));
     mettre_a_jour_statuts_chasse($post_id);
   }

--- a/inc/edition/edition-enigme.php
+++ b/inc/edition/edition-enigme.php
@@ -90,16 +90,8 @@ function creer_enigme_pour_chasse($chasse_id, $user_id = null)
   update_field('enigme_chasse_associee', $chasse_id, $enigme_id);
   update_field('enigme_organisateur_associe', $organisateur_id, $enigme_id);
 
-  mettre_a_jour_sous_champ_group(
-    $enigme_id,
-    'enigme_tentative',
-    'enigme_tentative_max',
-    5,
-    [
-      'enigme_tentative_cout_points' => 0,
-      'enigme_tentative_max'         => 5,
-    ]
-  );
+  update_field('enigme_tentative_cout_points', 0, $enigme_id);
+  update_field('enigme_tentative_max', 5, $enigme_id);
 
   update_field('enigme_reponse_casse', true, $enigme_id);
   update_field('enigme_acces_condition', 'immediat', $enigme_id);
@@ -274,11 +266,11 @@ function modifier_champ_enigme()
 
   // 🔹 Tentatives (coût et max)
   if ($champ === 'enigme_tentative.enigme_tentative_cout_points') {
-    $champ_valide = mettre_a_jour_sous_champ_group($post_id, 'enigme_tentative', 'enigme_tentative_cout_points', (int) $valeur);
+    $champ_valide = update_field('enigme_tentative_cout_points', (int) $valeur, $post_id) !== false;
   }
 
   if ($champ === 'enigme_tentative.enigme_tentative_max') {
-    $champ_valide = mettre_a_jour_sous_champ_group($post_id, 'enigme_tentative', 'enigme_tentative_max', (int) $valeur);
+    $champ_valide = update_field('enigme_tentative_max', (int) $valeur, $post_id) !== false;
   }
 
   // 🔹 Accès : condition (immédiat, date_programmee uniquement)

--- a/inc/edition/edition-organisateur.php
+++ b/inc/edition/edition-organisateur.php
@@ -86,15 +86,8 @@ function creer_organisateur_pour_utilisateur($user_id)
   $user_data = get_userdata($user_id);
   $email = $user_data ? $user_data->user_email : '';
 
-  $profil_public = get_field('profil_public', $post_id);
-  if (!is_array($profil_public)) {
-    $profil_public = [];
-  }
-
-  $profil_public['logo_organisateur'] = 3927;
-  $profil_public['email_contact'] = $email;
-
-  update_field('profil_public', $profil_public, $post_id);
+  update_field('profil_public_logo_organisateur', 3927, $post_id);
+  update_field('profil_public_email_contact', $email, $post_id);
 
   cat_debug("✅ Organisateur créé (pending) pour user $user_id : post ID $post_id");
 
@@ -254,17 +247,14 @@ function ajax_modifier_champ_organisateur()
     $iban = sanitize_text_field($donnees['iban'] ?? '');
     $bic  = sanitize_text_field($donnees['bic'] ?? '');
 
-    $ok = update_field('field_67d6715f90045', [
-      'iban' => $iban,
-      'bic'  => $bic,
-    ], $post_id);
+    $ok1 = update_field('gagnez_de_largent_iban', $iban, $post_id);
+    $ok2 = update_field('gagnez_de_largent_bic', $bic, $post_id);
 
-    // 🔍 Vérifie même si update_field retourne false
-    $enregistre = get_field('coordonnees_bancaires', $post_id);
-    $sameIban = ($enregistre['iban'] ?? '') === $iban;
-    $sameBic  = ($enregistre['bic'] ?? '') === $bic;
-
-    if ($ok || ($sameIban && $sameBic)) {
+    $enregistre_iban = get_field('gagnez_de_largent_iban', $post_id);
+    $enregistre_bic  = get_field('gagnez_de_largent_bic', $post_id);
+    $sameIban = $enregistre_iban === $iban;
+    $sameBic  = $enregistre_bic === $bic;
+    if (($ok1 !== false && $ok2 !== false) || ($sameIban && $sameBic)) {
       wp_send_json_success([
         'champ'  => $champ,
         'valeur' => ['iban' => $iban, 'bic' => $bic]

--- a/inc/relations-functions.php
+++ b/inc/relations-functions.php
@@ -62,11 +62,10 @@ function get_organisateur_chasse($chasse_id)
  */
 function get_organisateur_from_chasse($chasse_id)
 {
-  // ✅ Lecture directe via ACF du groupe
-  $champs_caches = get_field('champs_caches', $chasse_id);
+  // ✅ Lecture directe
+  $relation = get_field('champs_caches_chasse_cache_organisateur', $chasse_id);
 
-  if (!empty($champs_caches['chasse_cache_organisateur'])) {
-    $relation = $champs_caches['chasse_cache_organisateur'];
+  if (!empty($relation)) {
 
     // Gère tableau ou objet
     if (is_array($relation)) {
@@ -322,8 +321,7 @@ function recuperer_enigmes_associees(int $chasse_id): array
     return [];
   }
 
-  $groupe = get_field('champs_caches', $chasse_id);
-  $liste_brute = $groupe['chasse_cache_enigmes'] ?? [];
+  $liste_brute = get_field('champs_caches_chasse_cache_enigmes', $chasse_id) ?? [];
 
   // Extraction des IDs (objet ou int)
   $ids = [];
@@ -742,8 +740,7 @@ function forcer_relation_enigme_dans_chasse_si_absente(int $enigme_id): void
     return;
   }
 
-  $groupe = get_field('champs_caches', $chasse_id);
-  $liste = is_array($groupe['chasse_cache_enigmes'] ?? null) ? array_map('intval', $groupe['chasse_cache_enigmes']) : [];
+  $liste = is_array(get_field('champs_caches_chasse_cache_enigmes', $chasse_id) ?? null) ? array_map('intval', get_field('champs_caches_chasse_cache_enigmes', $chasse_id)) : [];
 
   if (!in_array($enigme_id, $liste, true)) {
     $ok = modifier_relation_acf(

--- a/templates/page-traitement-validation-chasse.php
+++ b/templates/page-traitement-validation-chasse.php
@@ -35,12 +35,7 @@ if (!peut_valider_chasse($chasse_id, $user_id)) {
 forcer_statut_apres_acf($chasse_id, 'en_attente');
 
 // Met à jour le statut métier pour refléter l'attente de validation
-mettre_a_jour_sous_champ_group(
-    $chasse_id,
-    'champs_caches',
-    'chasse_cache_statut',
-    'en_attente'
-);
+update_field('champs_caches_chasse_cache_statut', 'en_attente', $chasse_id);
 
 wp_redirect(add_query_arg('validation_demandee', '1', get_permalink($chasse_id)));
 exit;


### PR DESCRIPTION
## Summary
- use direct ACF field names for chasse/organisateur/enigme logic
- simplify statut and relation helpers
- avoid using `mettre_a_jour_sous_champ_group()`

## Testing
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_685d629cf6d88332b94845ac25d21bed