### PR TITLE
Flatten ACF field names in JS

### DIFF
--- a/assets/js/chasse-edit.js
+++ b/assets/js/chasse-edit.js
@@ -165,9 +165,9 @@ document.addEventListener('DOMContentLoaded', () => {
       if (!confirm('Voulez-vous vraiment supprimer la récompense ?')) return;
 
       const champsASupprimer = [
-        'caracteristiques.chasse_infos_recompense_titre',
-        'caracteristiques.chasse_infos_recompense_texte',
-        'caracteristiques.chasse_infos_recompense_valeur'
+        'chasse_infos_recompense_titre',
+        'chasse_infos_recompense_texte',
+        'chasse_infos_recompense_valeur'
       ];
 
       Promise.all(
@@ -223,7 +223,7 @@ document.addEventListener('DOMContentLoaded', () => {
         headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
         body: new URLSearchParams({
           action: 'modifier_champ_chasse',
-          champ: 'caracteristiques.chasse_infos_recompense_titre',
+          champ: 'chasse_infos_recompense_titre',
           valeur: titre,
           post_id: postId
         })
@@ -239,7 +239,7 @@ document.addEventListener('DOMContentLoaded', () => {
               headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
               body: new URLSearchParams({
                 action: 'modifier_champ_chasse',
-                champ: 'caracteristiques.chasse_infos_recompense_texte',
+                champ: 'chasse_infos_recompense_texte',
                 valeur: texte,
                 post_id: postId
               })
@@ -259,7 +259,7 @@ document.addEventListener('DOMContentLoaded', () => {
               headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
               body: new URLSearchParams({
                 action: 'modifier_champ_chasse',
-                champ: 'caracteristiques.chasse_infos_recompense_valeur',
+                champ: 'chasse_infos_recompense_valeur',
                 valeur: valeur,
                 post_id: postId
               })
@@ -445,7 +445,7 @@ document.querySelectorAll('.champ-cout-points .champ-enregistrer').forEach(bouto
 
     modifierChampSimple(champ, valeur, postId, 'chasse');
 
-    if (champ === 'caracteristiques.chasse_infos_cout_points') {
+    if (champ === 'chasse_infos_cout_points') {
       mettreAJourAffichageCout(postId, valeur);
       rafraichirStatutChasse(postId);
     }
@@ -504,12 +504,12 @@ function initChampNbGagnants() {
     if (checkboxIllimite.checked) {
       inputNb.disabled = true;
       inputNb.value = '0';
-      modifierChampSimple('caracteristiques.chasse_infos_nb_max_gagants', 0, postId, 'chasse');
+      modifierChampSimple('chasse_infos_nb_max_gagants', 0, postId, 'chasse');
     } else {
       inputNb.disabled = false;
       if (parseInt(inputNb.value.trim(), 10) === 0 || inputNb.value.trim() === '') {
         inputNb.value = '1';
-        modifierChampSimple('caracteristiques.chasse_infos_nb_max_gagants', 1, postId, 'chasse');
+        modifierChampSimple('chasse_infos_nb_max_gagants', 1, postId, 'chasse');
       }
     }
     // 🔥 Mise à jour dynamique après changement illimité
@@ -527,7 +527,7 @@ function initChampNbGagnants() {
         valeur = 1;
         inputNb.value = '1';
       }
-      modifierChampSimple('caracteristiques.chasse_infos_nb_max_gagants', valeur, postId, 'chasse');
+      modifierChampSimple('chasse_infos_nb_max_gagants', valeur, postId, 'chasse');
       mettreAJourAffichageNbGagnants(postId, valeur); // ✅ ici, APRES avoir défini valeur
     }, 500);
   });

--- a/assets/js/core/champ-date-hooks.js
+++ b/assets/js/core/champ-date-hooks.js
@@ -8,15 +8,15 @@ window.onDateFieldUpdated = function(input, valeur) {
   if (!champ) return;
 
   const handlers = {
-    'enigme_acces.date': (val) => {
+    'enigme_acces_date': (val) => {
       const span = document.querySelector('.date-deblocage');
       if (span) span.textContent = formatDateFr(val);
     },
-    'caracteristiques.chasse_infos_date_debut': (val) => {
+    'chasse_infos_date_debut': (val) => {
       const span = document.querySelector('.date-debut');
       if (span) span.textContent = formatDateFr(val);
     },
-    'caracteristiques.chasse_infos_date_fin': (val) => {
+    'chasse_infos_date_fin': (val) => {
       const span = document.querySelector('.date-fin');
       if (span) span.textContent = formatDateFr(val);
     }

--- a/assets/js/core/champ-init.js
+++ b/assets/js/core/champ-init.js
@@ -83,7 +83,7 @@ function initChampTexte(bloc) {
     feedback.textContent = '';
     feedback.className = 'champ-feedback';
 
-    if (champ === 'profil_public_email_contact') {
+    if (champ === 'email_contact') {
       const fallback = window.organisateurData?.defaultEmail || '…';
       const affichageTexte = affichage.querySelector('p');
       if (affichageTexte && input.value.trim() === '') {
@@ -105,7 +105,7 @@ function initChampTexte(bloc) {
     const valeur = input.value.trim();
     if (!champ || !postId) return;
 
-    if (champ === 'profil_public_email_contact') {
+    if (champ === 'email_contact') {
       const isValide = valeur === '' || /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(valeur);
       if (!isValide) {
         feedback.textContent = '⛔ Adresse email invalide';
@@ -137,7 +137,7 @@ function initChampTexte(bloc) {
       if (success) {
         const affichageTexte = affichage.querySelector('h1, h2, p, span');
 
-        if (champ === 'profil_public_email_contact') {
+        if (champ === 'email_contact') {
           const fallbackEmail = window.organisateurData?.defaultEmail || '…';
           const p = affichage.querySelector('p');
           if (p) {
@@ -280,7 +280,7 @@ function initChampCoutPoints() {
 
         // ✅ Mise à jour visuelle du badge coût pour la chasse
         if (
-          champ === 'caracteristiques.chasse_infos_cout_points' &&
+          champ === 'chasse_infos_cout_points' &&
           typeof mettreAJourAffichageCout === 'function'
         ) {
           mettreAJourAffichageCout(postId, valeur);

--- a/assets/js/core/resume.js
+++ b/assets/js/core/resume.js
@@ -41,7 +41,7 @@ window.mettreAJourResumeInfos = function () {
       const champ = ligne.dataset.champ;
 
       // 🎯 [NOUVEAU] Ignorer les champs du groupe caractéristiques
-      if (champ.startsWith('caracteristiques.') && champ !== 'caracteristiques_chasse_infos_recompense_valeur') {
+      if (champ.startsWith('chasse_infos_') && champ !== 'chasse_infos_recompense_valeur') {
         return; // On saute toutes sauf la récompense
       }
 
@@ -76,7 +76,7 @@ window.mettreAJourResumeInfos = function () {
         estRempli = ul && ul.children.length > 0;
       }
 
-      if (champ === 'caracteristiques_chasse_infos_recompense_valeur') {
+      if (champ === 'chasse_infos_recompense_valeur') {
         const titre = document.getElementById('champ-recompense-titre')?.value.trim();
         const texte = document.getElementById('champ-recompense-texte')?.value.trim();
         const valeur = parseFloat(document.getElementById('champ-recompense-valeur')?.value || '0');
@@ -125,12 +125,12 @@ window.mettreAJourResumeInfos = function () {
         estRempli = !!checked;
       }
 
-      if (champ === 'enigme_tentative.enigme_tentative_cout_points') {
+      if (champ === 'enigme_tentative_cout_points') {
         const val = parseInt(blocEdition?.querySelector('input')?.value || '', 10);
         estRempli = !isNaN(val);
       }
 
-      if (champ === 'enigme_tentative.enigme_tentative_max') {
+      if (champ === 'enigme_tentative_max') {
         const val = parseInt(blocEdition?.querySelector('input')?.value || '', 10);
         estRempli = !isNaN(val) && val > 0;
       }
@@ -214,16 +214,16 @@ window.onChampSimpleMisAJour = function (champ, postId, valeur, cpt) {
     if (champ === 'post_title' && typeof window.mettreAJourTitreHeader === 'function') {
       window.mettreAJourTitreHeader(cpt, valeur);
     }
-    if (champ === 'profil_public_logo_organisateur') {
+    if (champ === 'logo_organisateur') {
       const bloc = document.querySelector(`.champ-organisateur[data-champ="${champ}"][data-post-id="${postId}"]`);
       if (bloc && typeof bloc.__ouvrirMedia === 'function') bloc.__ouvrirMedia();
     }
     const champsResume = [
       'post_title',
       'description_longue',
-      'profil_public_logo',
-      'profil_public_logo_organisateur',
-      'profil_public_email_contact',
+      'logo',
+      'logo_organisateur',
+      'email_contact',
       'coordonnees_bancaires',
       'liens_publics'
     ];
@@ -242,12 +242,12 @@ window.onChampSimpleMisAJour = function (champ, postId, valeur, cpt) {
       if (bloc && typeof bloc.__ouvrirMedia === 'function') bloc.__ouvrirMedia();
     }
     const champsStatut = [
-      'caracteristiques.chasse_infos_date_debut',
-      'caracteristiques.chasse_infos_date_fin',
-      'caracteristiques.chasse_infos_duree_illimitee',
-      'caracteristiques.chasse_infos_cout_points',
-      'champs_caches.chasse_cache_statut',
-      'champs_caches.chasse_cache_statut_validation'
+      'chasse_infos_date_debut',
+      'chasse_infos_date_fin',
+      'chasse_infos_duree_illimitee',
+      'chasse_infos_cout_points',
+      'chasse_cache_statut',
+      'chasse_cache_statut_validation'
     ];
     if (champsStatut.includes(champ)) {
       rafraichirStatutChasse(postId);
@@ -261,8 +261,8 @@ window.onChampSimpleMisAJour = function (champ, postId, valeur, cpt) {
       'enigme_visuel_legende',
       'enigme_visuel_texte',
       'enigme_mode_validation',
-      'enigme_tentative.enigme_tentative_cout_points',
-      'enigme_tentative.enigme_tentative_max',
+      'enigme_tentative_cout_points',
+      'enigme_tentative_max',
       'enigme_reponse_bonne',
       'enigme_reponse_casse',
       'enigme_acces_condition',

--- a/assets/js/enigme-edit.js
+++ b/assets/js/enigme-edit.js
@@ -143,7 +143,7 @@ document.addEventListener('DOMContentLoaded', () => {
   // ==============================
   // 💰 Affichage dynamique tentatives (message coût)
   // ==============================
-  const blocCout = document.querySelector('[data-champ="enigme_tentative.enigme_tentative_cout_points"]');
+  const blocCout = document.querySelector('[data-champ="enigme_tentative_cout_points"]');
   if (blocCout && typeof window.onCoutPointsUpdated === 'function') {
     const champ = blocCout.dataset.champ;
     const valeur = parseInt(blocCout.querySelector('.champ-input')?.value || '0', 10);
@@ -378,7 +378,7 @@ document.querySelector('#panneau-images-enigme .panneau-fermer')?.addEventListen
 // 🔢 Initialisation champ enigme_tentative_max (tentatives/jour)
 // ================================
 function initChampNbTentatives() {
-  const bloc = document.querySelector('[data-champ="enigme_tentative.enigme_tentative_max"]');
+  const bloc = document.querySelector('[data-champ="enigme_tentative_max"]');
   if (!bloc) return;
 
   const input = bloc.querySelector('.champ-input');
@@ -401,7 +401,7 @@ function initChampNbTentatives() {
 
   // 🔄 Fonction centralisée
   function mettreAJourAideTentatives() {
-    const coutInput = document.querySelector('[data-champ="enigme_tentative.enigme_tentative_cout_points"] .champ-input');
+    const coutInput = document.querySelector('[data-champ="enigme_tentative_cout_points"] .champ-input');
     if (!coutInput) return;
 
     const cout = parseInt(coutInput.value.trim(), 10);
@@ -429,7 +429,7 @@ function initChampNbTentatives() {
       input.value = '1';
     }
 
-    const coutInput = document.querySelector('[data-champ="enigme_tentative.enigme_tentative_cout_points"] .champ-input');
+    const coutInput = document.querySelector('[data-champ="enigme_tentative_cout_points"] .champ-input');
     const cout = parseInt(coutInput?.value.trim() || '0', 10);
     const estGratuit = isNaN(cout) || cout === 0;
 
@@ -448,8 +448,8 @@ function initChampNbTentatives() {
   mettreAJourAideTentatives();
 
   // 🔁 Lié aux modifs de coût (input + checkbox)
-  const coutInput = document.querySelector('[data-champ="enigme_tentative.enigme_tentative_cout_points"] .champ-input');
-  const checkbox = document.querySelector('[data-champ="enigme_tentative.enigme_tentative_cout_points"] input[type="checkbox"]');
+  const coutInput = document.querySelector('[data-champ="enigme_tentative_cout_points"] .champ-input');
+  const checkbox = document.querySelector('[data-champ="enigme_tentative_cout_points"] input[type="checkbox"]');
   if (coutInput) coutInput.addEventListener('input', mettreAJourAideTentatives);
   if (checkbox) checkbox.addEventListener('change', mettreAJourAideTentatives);
 
@@ -463,8 +463,8 @@ function initChampNbTentatives() {
 // 💰 Hook personnalisé – Réaction au champ coût (CPT énigme uniquement)
 // ================================
 window.onCoutPointsUpdated = function (bloc, champ, valeur, postId, cpt) {
-  if (champ === 'enigme_tentative.enigme_tentative_cout_points') {
-    const champMax = document.querySelector('[data-champ="enigme_tentative.enigme_tentative_max"] .champ-input');
+  if (champ === 'enigme_tentative_cout_points') {
+    const champMax = document.querySelector('[data-champ="enigme_tentative_max"] .champ-input');
     if (champMax) {
       const valeurActuelle = parseInt(champMax.value, 10);
 
@@ -475,7 +475,7 @@ window.onCoutPointsUpdated = function (bloc, champ, valeur, postId, cpt) {
         // Si supérieur, on ramène à 24 (ou 5 selon logique métier ? à vérifier)
         if (valeurActuelle > 24) {
           champMax.value = '24';
-          modifierChampSimple('enigme_tentative.enigme_tentative_max', 24, postId, cpt);
+          modifierChampSimple('enigme_tentative_max', 24, postId, cpt);
         }
       } else {
         // Mode payant → aucune limite
@@ -740,7 +740,7 @@ window.onDateFieldUpdated = function (input, nouvelleValeur) {
   const bloc = input.closest('[data-champ]');
   const champ = bloc?.dataset.champ;
 
-  if (champ !== 'enigme_acces.date') return;
+  if (champ !== 'enigme_acces_date') return;
 
   const valeur = input.value?.trim() || '';
 

--- a/assets/js/organisateur-edit.js
+++ b/assets/js/organisateur-edit.js
@@ -177,7 +177,7 @@ window.mettreAJourCarteAjoutChasse = function () {
   // 🔍 Champs JS dynamiques
   const champsJS = [
     '[data-champ="post_title"]',
-    '[data-champ="profil_public_logo_organisateur"]'
+    '[data-champ="logo_organisateur"]'
   ];
 
   // 🔁 Vérifie visuellement ceux qui sont vides


### PR DESCRIPTION
## Summary
- refactor JS files to use flat ACF field names
- update résumé field arrays

## Testing
- `composer install` *(fails: command not found)*
- `vendor/bin/phpunit --configuration tests/phpunit.xml` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_685d62cb2870833298e9635e663d84eb