### PR TITLE
Refactor ACF field access

### DIFF
--- a/template-parts/chasse/chasse-affichage-complet.php
+++ b/template-parts/chasse/chasse-affichage-complet.php
@@ -12,22 +12,18 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
 
 
 // Champs ACF principaux
-$caracteristiques = get_field('caracteristiques', $chasse_id);
-$champs_caches = get_field('champs_caches', $chasse_id);
-
-// Champs individuels
-$lot = $caracteristiques['chasse_infos_recompense_texte'] ?? '';
-$titre_recompense = $caracteristiques['chasse_infos_recompense_titre'] ?? '';
-$valeur_recompense = $caracteristiques['chasse_infos_recompense_valeur'] ?? '';
-$cout_points = $caracteristiques['chasse_infos_cout_points'] ?? 0;
-$date_debut = $caracteristiques['chasse_infos_date_debut'] ?? null;
-$date_fin = $caracteristiques['chasse_infos_date_fin'] ?? null;
-$illimitee = $caracteristiques['chasse_infos_duree_illimitee'] ?? false;
-$nb_max = $caracteristiques['chasse_infos_nb_max_gagants'] ?? 0;
+$lot               = get_field('chasse_infos_recompense_texte', $chasse_id);
+$titre_recompense  = get_field('chasse_infos_recompense_titre', $chasse_id);
+$valeur_recompense = get_field('chasse_infos_recompense_valeur', $chasse_id);
+$cout_points       = get_field('chasse_infos_cout_points', $chasse_id) ?: 0;
+$date_debut        = get_field('chasse_infos_date_debut', $chasse_id);
+$date_fin          = get_field('chasse_infos_date_fin', $chasse_id);
+$illimitee         = get_field('chasse_infos_duree_illimitee', $chasse_id);
+$nb_max            = get_field('chasse_infos_nb_max_gagants', $chasse_id) ?: 0;
 
 // Champs cachés
-$date_decouverte = $champs_caches['chasse_cache_date_decouverte'] ?? null;
-$current_stored_statut = $champs_caches['chasse_cache_statut'] ?? null;
+$date_decouverte      = get_field('chasse_cache_date_decouverte', $chasse_id);
+$current_stored_statut = get_field('chasse_cache_statut', $chasse_id);
 
 // Données supplémentaires
 $description = get_field('chasse_principale_description', $chasse_id);
@@ -59,7 +55,7 @@ $organisateur_nom = $organisateur_id ? get_the_title($organisateur_id) : get_the
 if (current_user_can('administrator')) {
   $chasse_id = get_the_ID();
 
-  error_log("📦 [TEST] Statut stocké (admin) : " . get_field('champs_caches')['chasse_cache_statut']);
+  error_log("📦 [TEST] Statut stocké (admin) : " . get_field('chasse_cache_statut', $chasse_id));
 
   verifier_ou_recalculer_statut_chasse($chasse_id);
 
@@ -82,8 +78,7 @@ if ($edition_active && !$est_complet) {
 
   <div class="chasse-fiche-container flex-row">
     <?php
-    $cache = get_field('champs_caches', $chasse_id);
-    $statut = get_field('champs_caches')['chasse_cache_statut'] ?? 'revision';
+    $statut = get_field('chasse_cache_statut', $chasse_id) ?? 'revision';
     ?>
       <span class="badge-statut statut-<?= esc_attr($statut); ?>" data-post-id="<?= esc_attr($chasse_id); ?>">
         <?= ucfirst(str_replace('_', ' ', $statut)); ?>

--- a/template-parts/chasse/chasse-edition-main.php
+++ b/template-parts/chasse/chasse-edition-main.php
@@ -19,13 +19,11 @@ $image = get_field('chasse_principale_image', $chasse_id);
 $description = get_field('chasse_principale_description', $chasse_id);
 $titre = get_the_title($chasse_id);
 $liens = get_field('chasse_principale_liens', $chasse_id);
-$carac = get_field('caracteristiques', $chasse_id);
-
-$recompense = $carac['chasse_infos_recompense_texte'] ?? '';
-$valeur     = $carac['chasse_infos_recompense_valeur'] ?? '';
-$cout       = $carac['chasse_infos_cout_points'] ?? '';
-$date_debut = $carac['chasse_infos_date_debut'] ?? '';
-$date_fin   = $carac['chasse_infos_date_fin'] ?? '';
+$recompense = get_field('chasse_infos_recompense_texte', $chasse_id);
+$valeur     = get_field('chasse_infos_recompense_valeur', $chasse_id);
+$cout       = get_field('chasse_infos_cout_points', $chasse_id);
+$date_debut = get_field('chasse_infos_date_debut', $chasse_id);
+$date_fin   = get_field('chasse_infos_date_fin', $chasse_id);
 
 // 🎯 Conversion des dates pour les champs <input>
 $date_debut_obj = convertir_en_datetime($date_debut);
@@ -33,8 +31,8 @@ $date_debut_iso = $date_debut_obj ? $date_debut_obj->format('Y-m-d\TH:i') : '';
 
 $date_fin_obj = convertir_en_datetime($date_fin);
 $date_fin_iso = $date_fin_obj ? $date_fin_obj->format('Y-m-d') : '';
-$illimitee  = $carac['chasse_infos_duree_illimitee'] ?? false;
-$nb_max     = $carac['chasse_infos_nb_max_gagants'] ?? 1;
+$illimitee  = get_field('chasse_infos_duree_illimitee', $chasse_id);
+$nb_max     = get_field('chasse_infos_nb_max_gagants', $chasse_id) ?: 1;
 
 $champTitreParDefaut = 'nouvelle chasse'; // À adapter si besoin
 $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut);
@@ -143,11 +141,11 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
               <ul class="resume-infos">
 
                 <!-- Récompense -->
-                <li class="champ-chasse champ-rempli<?= $peut_editer ? '' : ' champ-desactive'; ?>" data-champ="caracteristiques_chasse_infos_recompense_valeur" data-cpt="chasse" data-post-id="<?= esc_attr($chasse_id); ?>">
+                <li class="champ-chasse champ-rempli<?= $peut_editer ? '' : ' champ-desactive'; ?>" data-champ="chasse_infos_recompense_valeur" data-cpt="chasse" data-post-id="<?= esc_attr($chasse_id); ?>">
                   Récompense
                   <?php if ($peut_editer) : ?>
 
-                    <button type="button" class="champ-modifier ouvrir-panneau-recompense" data-champ="caracteristiques_chasse_infos_recompense_valeur" data-cpt="chasse" data-post-id="<?= esc_attr($chasse_id); ?>" aria-label="Modifier la récompense">✏️</button>
+                    <button type="button" class="champ-modifier ouvrir-panneau-recompense" data-champ="chasse_infos_recompense_valeur" data-cpt="chasse" data-post-id="<?= esc_attr($chasse_id); ?>" aria-label="Modifier la récompense">✏️</button>
 
                   <?php endif; ?>
                 </li>
@@ -182,7 +180,7 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
 
                 <!-- Date de début (édition inline) -->
                 <li class="champ-chasse champ-date-debut<?= $peut_editer ? '' : ' champ-desactive'; ?>"
-                  data-champ="caracteristiques.chasse_infos_date_debut"
+                  data-champ="chasse_infos_date_debut"
                   data-cpt="chasse"
                   data-post-id="<?= esc_attr($chasse_id); ?>">
 
@@ -198,7 +196,7 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
 
                 <!-- Date de fin -->
                 <li class="champ-chasse champ-date-fin<?= $peut_editer ? '' : ' champ-desactive'; ?>"
-                  data-champ="caracteristiques.chasse_infos_date_fin"
+                  data-champ="chasse_infos_date_fin"
                   data-cpt="chasse"
                   data-post-id="<?= esc_attr($chasse_id); ?>">
 
@@ -214,7 +212,7 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
                     <input type="checkbox"
                       id="duree-illimitee"
                       name="duree-illimitee"
-                      data-champ="caracteristiques.chasse_infos_duree_illimitee"
+                      data-champ="chasse_infos_duree_illimitee"
                       <?= ($illimitee ? 'checked' : ''); ?> <?= $peut_editer ? '' : 'disabled'; ?>>
                     <label for="duree-illimitee">Durée illimitée</label>
                   </div>
@@ -224,7 +222,7 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
 
                 <!-- Coût -->
                 <li class="champ-chasse champ-cout-points <?= empty($cout) ? 'champ-vide' : 'champ-rempli'; ?><?= $peut_editer ? '' : ' champ-desactive'; ?>"
-                  data-champ="caracteristiques.chasse_infos_cout_points"
+                  data-champ="chasse_infos_cout_points"
                   data-cpt="chasse"
                   data-post-id="<?= esc_attr($chasse_id); ?>">
 
@@ -255,7 +253,7 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
 
                 <!-- Nombre de gagnants -->
                 <li class="champ-chasse champ-nb-gagnants <?= empty($nb_max) ? 'champ-vide' : 'champ-rempli'; ?><?= $peut_editer ? '' : ' champ-desactive'; ?>"
-                  data-champ="caracteristiques.chasse_infos_nb_max_gagants"
+                  data-champ="chasse_infos_nb_max_gagants"
                   data-cpt="chasse"
                   data-post-id="<?= esc_attr($chasse_id); ?>">
 
@@ -274,7 +272,7 @@ $isTitreParDefaut = strtolower(trim($titre)) === strtolower($champTitreParDefaut
                       id="nb-gagnants-illimite"
                       name="nb-gagnants-illimite"
                       <?= ($nb_max == 0 ? 'checked' : ''); ?> <?= $peut_editer ? '' : 'disabled'; ?>
-                      data-champ="caracteristiques.chasse_infos_nb_max_gagants">
+                      data-champ="chasse_infos_nb_max_gagants">
                     <label for="nb-gagnants-illimite">Illimité</label>
                   </div>
 

--- a/template-parts/chasse/panneaux/chasse-edition-recompense.php
+++ b/template-parts/chasse/panneaux/chasse-edition-recompense.php
@@ -3,9 +3,8 @@ defined('ABSPATH') || exit;
 $chasse_id = $args['chasse_id'] ?? null;
 if (!$chasse_id || get_post_type($chasse_id) !== 'chasse') return;
 
-$caracteristiques = get_field('caracteristiques', $chasse_id);
-$texte_recompense = $caracteristiques['chasse_infos_recompense_texte'] ?? '';
-$valeur_recompense = $caracteristiques['chasse_infos_recompense_valeur'] ?? '';
+$texte_recompense  = get_field('chasse_infos_recompense_texte', $chasse_id);
+$valeur_recompense = get_field('chasse_infos_recompense_valeur', $chasse_id);
 ?>
 
 
@@ -20,7 +19,7 @@ $valeur_recompense = $caracteristiques['chasse_infos_recompense_valeur'] ?? '';
     <div class="champ-wrapper" style="display: flex; flex-direction: column; gap: 20px;">
         
       <label for="champ-recompense-titre">Titre de la récompense <span class="champ-obligatoire">*</span></label>
-      <input id="champ-recompense-titre" type="text" maxlength="40" placeholder="Ex : Un papillon en cristal..." value="<?= esc_attr($caracteristiques['chasse_infos_recompense_titre'] ?? ''); ?>">
+      <input id="champ-recompense-titre" type="text" maxlength="40" placeholder="Ex : Un papillon en cristal..." value="<?= esc_attr(get_field('chasse_infos_recompense_titre', $chasse_id)); ?>">
 
       <label for="champ-recompense-texte">Descripton de la récompense <span class="champ-obligatoire">*</span></label>
       <textarea id="champ-recompense-texte" rows="4" placeholder="Ex : Un coffret cadeau comprenant..."><?= esc_textarea(wp_strip_all_tags($texte_recompense)); ?></textarea>

--- a/template-parts/organisateur/organisateur-edition-main.php
+++ b/template-parts/organisateur/organisateur-edition-main.php
@@ -23,7 +23,8 @@ $description  = get_field('description_longue', $organisateur_id);
 $reseaux      = get_field('reseaux_sociaux', $organisateur_id);
 $site         = get_field('lien_site_web', $organisateur_id);
 $email_contact = get_field('profil_public_email_contact', $organisateur_id);
-$coordonnees  = get_field('coordonnees_bancaires', $organisateur_id);
+$iban         = get_field('coordonnees_bancaires_iban', $organisateur_id);
+$bic          = get_field('coordonnees_bancaires_bic', $organisateur_id);
 $liens_actifs = organisateur_get_liens_actifs($organisateur_id);
 $nb_liens = count($liens_actifs);
 
@@ -35,9 +36,8 @@ $is_complete = (
   !empty($description)
 );
 
-$coordonnees = get_field('coordonnees_bancaires', $organisateur_id);
-$iban_vide = empty($coordonnees['iban']);
-$bic_vide  = empty($coordonnees['bic']);
+$iban_vide = empty($iban);
+$bic_vide  = empty($bic);
 $classe_vide_coordonnees = ($iban_vide || $bic_vide) ? 'champ-vide' : '';
 ?>
 
@@ -222,7 +222,7 @@ $classe_vide_coordonnees = ($iban_vide || $bic_vide) ? 'champ-vide' : '';
                 <h3>Information bancaires</h3>
 
                 <ul class="resume-infos">
-                  <li class="champ-organisateur champ-coordonnees ligne-coordonnees <?= !empty($coordonnees['iban']) ? 'champ-rempli' : ''; ?>" data-champ="coordonnees_bancaires">
+                  <li class="champ-organisateur champ-coordonnees ligne-coordonnees <?= !empty($iban) ? 'champ-rempli' : ''; ?>" data-champ="coordonnees_bancaires">
                     Coordonnées bancaires
                     <button type="button" class="icone-info" aria-label="Informations sur les coordonnées bancaires"
                       onclick="alert('Ces informations sont nécessaires uniquement pour vous verser les gains issus de la conversion de vos points en euros. Nous ne prélevons jamais d\u2019argent.');">

--- a/template-parts/organisateur/organisateur-header.php
+++ b/template-parts/organisateur/organisateur-header.php
@@ -14,9 +14,10 @@ if (!is_numeric($organisateur_id)) return;
 $liens_actifs = organisateur_get_liens_actifs($organisateur_id);
 $types_disponibles = organisateur_get_liste_liens_publics(); // à garder si nécessaire
 
-$coordonnees = get_field('coordonnees_bancaires', $organisateur_id);
-$iban_vide = empty($coordonnees['iban']);
-$bic_vide  = empty($coordonnees['bic']);
+$iban  = get_field('coordonnees_bancaires_iban', $organisateur_id);
+$bic   = get_field('coordonnees_bancaires_bic', $organisateur_id);
+$iban_vide = empty($iban);
+$bic_vide  = empty($bic);
 $classe_vide_coordonnees = ($iban_vide || $bic_vide) ? 'champ-vide' : '';
 
 $base_url = get_permalink($organisateur_id);

--- a/template-parts/organisateur/organisateur-partial-chasse-card.php
+++ b/template-parts/organisateur/organisateur-partial-chasse-card.php
@@ -21,15 +21,14 @@ $description = get_field('description_chasse', $chasse_id);
 $statut = mettre_a_jour_statuts_chasse($chasse_id);
 
 // 🔹 Récupération des groupes ACF
-$caracteristiques = get_field('caracteristiques', $chasse_id) ?? [];
 $trophee = get_field('trophee', $chasse_id) ?? [];
 
-// 🔹 Extraction des sous-champs depuis leurs groupes
-$date_debut = $caracteristiques['date_de_debut'] ?? null;
-$date_fin = $caracteristiques['date_de_fin'] ?? null;
-$illimitee = $caracteristiques['illimitee'] ?? null; // "stop" ou "continue"
-$valeur_tresor = $caracteristiques['contre_valeur_tresor'] ?? null;
-$lot_description = $caracteristiques['lot'] ?? null;
+// 🔹 Lecture directe des sous-champs ACF
+$date_debut     = get_field('chasse_infos_date_debut', $chasse_id);
+$date_fin       = get_field('chasse_infos_date_fin', $chasse_id);
+$illimitee      = get_field('chasse_infos_duree_illimitee', $chasse_id); // "stop" ou "continue"
+$valeur_tresor  = get_field('contre_valeur_tresor', $chasse_id);
+$lot_description = get_field('lot', $chasse_id);
 
 $nb_joueurs = get_field('total_joueurs_souscription_chasse', $chasse_id);
 
@@ -144,9 +143,8 @@ $classe_verrouillee = ($statut === 'Verrouillée') ? 'statut-verrouille' : '';
             <div class="chasse-terminee">
                 <?php 
                 // 🔹 Date de découverte
-                $champs_caches = get_field('champs_caches', $chasse_id);
-                $date_decouverte = $champs_caches['date_de_decouverte'] ?? null;
-                $gagnants = $champs_caches['gagnant'] ?? [];
+                $date_decouverte = get_field('date_de_decouverte', $chasse_id);
+                $gagnants = get_field('gagnant', $chasse_id) ?? [];
                 ?>
                 <p>
                     <?php echo esc_html($date_decouverte ? formater_date($date_decouverte) : __('Solution non trouvée', 'textdomain')); ?>

--- a/template-parts/organisateur/panneaux/organisateur-edition-coordonnees.php
+++ b/template-parts/organisateur/panneaux/organisateur-edition-coordonnees.php
@@ -6,9 +6,8 @@ $organisateur_id = $args['organisateur_id']
     ?? get_query_var('organisateur_id_force')
     ?? get_organisateur_from_user(get_current_user_id());
 
-$coordonnees = get_field('coordonnees_bancaires', $organisateur_id);
-$iban = $coordonnees['iban'] ?? '';
-$bic  = $coordonnees['bic'] ?? '';
+$iban = get_field('coordonnees_bancaires_iban', $organisateur_id);
+$bic  = get_field('coordonnees_bancaires_bic', $organisateur_id);
 ?>
 
 <div id="panneau-coordonnees" class="panneau-lateral-liens" aria-hidden="true" role="dialog">


### PR DESCRIPTION
## Summary
- refactor usage of ACF groups in template parts
- call subfields directly with `get_field`
- update data-champ attributes to match root field names

## Testing
- `vendor/bin/phpunit --configuration tests/phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_685d635778388332b0a82cff5c5ae7ef