### PR TITLE
Remove champs_caches prefix from meta keys

### DIFF
--- a/inc/access-functions.php
+++ b/inc/access-functions.php
@@ -298,7 +298,7 @@ function utilisateur_peut_creer_post($post_type, $chasse_id = null)
             }
 
             // ✅ Vérifier que la chasse est en "création"
-            $validation = get_field('champs_caches_chasse_cache_statut_validation', $chasse_id);
+            $validation = get_field('chasse_cache_statut_validation', $chasse_id);
             return trim($validation ?? '') === 'creation';
     }
 
@@ -403,7 +403,7 @@ function utilisateur_peut_voir_enigme(int $enigme_id, ?int $user_id = null): boo
 
     // ✅ Exception organisateur : accès si chasse en création, correction
     //    ou en attente de validation
-    $statut_validation = get_field('champs_caches_chasse_cache_statut_validation', $chasse_id);
+    $statut_validation = get_field('chasse_cache_statut_validation', $chasse_id);
     error_log("🧪 [voir énigme] chasse #$chasse_id → statut_validation = $statut_validation");
 
     if (in_array($statut_validation, ['creation', 'correction', 'en_attente'], true)) {
@@ -449,8 +449,8 @@ function utilisateur_peut_ajouter_enigme(int $chasse_id, ?int $user_id = null): 
         return false;
     }
 
-    $statut_validation = get_field('champs_caches_chasse_cache_statut_validation', $chasse_id);
-    $statut_metier     = get_field('champs_caches_chasse_cache_statut', $chasse_id);
+    $statut_validation = get_field('chasse_cache_statut_validation', $chasse_id);
+    $statut_metier     = get_field('chasse_cache_statut', $chasse_id);
 
     if ($statut_metier !== 'revision') {
         error_log("❌ [ajout énigme] chasse #$chasse_id statut metier : $statut_metier");
@@ -501,7 +501,7 @@ function utilisateur_peut_modifier_enigme(int $enigme_id, ?int $user_id = null):
     if (!$chasse_id || get_post_type($chasse_id) !== 'chasse') return false;
 
     // Récupérer l'état de validation de la chasse
-    $statut_validation = get_field('champs_caches_chasse_cache_statut_validation', $chasse_id);
+    $statut_validation = get_field('chasse_cache_statut_validation', $chasse_id);
 
 
     // L'utilisateur doit être associé à l'organisateur de la chasse
@@ -539,8 +539,8 @@ function utilisateur_peut_supprimer_enigme(int $enigme_id, ?int $user_id = null)
         return false;
     }
 
-    $statut_validation = get_field('champs_caches_chasse_cache_statut_validation', $chasse_id);
-    $statut_metier     = get_field('champs_caches_chasse_cache_statut', $chasse_id);
+    $statut_validation = get_field('chasse_cache_statut_validation', $chasse_id);
+    $statut_metier     = get_field('chasse_cache_statut', $chasse_id);
 
     if ($statut_metier !== 'revision') {
         return false;
@@ -626,7 +626,7 @@ function utilisateur_peut_voir_panneau(int $post_id): bool
             return in_array($status, ['publish', 'pending'], true);
 
         case 'chasse':
-            $val = get_field('champs_caches_chasse_cache_statut_validation', $post_id) ?? '';
+            $val = get_field('chasse_cache_statut_validation', $post_id) ?? '';
 
             return in_array($status, ['publish', 'pending'], true) && $val !== 'banni';
 
@@ -665,8 +665,8 @@ function utilisateur_peut_editer_champs(int $post_id): bool
             return in_array(ROLE_ORGANISATEUR_CREATION, $roles, true) && $status === 'pending';
 
         case 'chasse':
-            $val     = get_field('champs_caches_chasse_cache_statut_validation', $post_id) ?? '';
-            $stat    = get_field('champs_caches_chasse_cache_statut', $post_id) ?? '';
+            $val     = get_field('chasse_cache_statut_validation', $post_id) ?? '';
+            $stat    = get_field('chasse_cache_statut', $post_id) ?? '';
             $complet = (bool) get_field('chasse_cache_complet', $post_id);
             $complet = (bool) get_field('chasse_cache_complet', $post_id);
 
@@ -687,8 +687,8 @@ function utilisateur_peut_editer_champs(int $post_id): bool
             }
 
             $chasse_status = get_post_status($chasse_id);
-            $val           = get_field('champs_caches_chasse_cache_statut_validation', $chasse_id) ?? '';
-            $stat          = get_field('champs_caches_chasse_cache_statut', $chasse_id) ?? '';
+            $val           = get_field('chasse_cache_statut_validation', $chasse_id) ?? '';
+            $stat          = get_field('chasse_cache_statut', $chasse_id) ?? '';
             $etat          = get_field('enigme_cache_etat_systeme', $post_id);
 
             return $chasse_status === 'pending'
@@ -1135,7 +1135,7 @@ function chasse_est_visible_pour_utilisateur(int $chasse_id, int $user_id): bool
         return false;
     }
 
-    $validation = get_field('champs_caches_chasse_cache_statut_validation', $chasse_id) ?? '';
+    $validation = get_field('chasse_cache_statut_validation', $chasse_id) ?? '';
 
     if ($status === 'pending') {
         $assoc = utilisateur_est_organisateur_associe_a_chasse($user_id, $chasse_id);

--- a/inc/admin-functions.php
+++ b/inc/admin-functions.php
@@ -1432,7 +1432,7 @@ function recuperer_organisateurs_pending() {
             verifier_ou_mettre_a_jour_cache_complet($chasse_id);
             $chasse_complet = (bool) get_field('chasse_cache_complet', $chasse_id);
             $nb_enigmes = count(recuperer_enigmes_associees($chasse_id));
-            $validation = get_field('champs_caches_chasse_cache_statut_validation', $chasse_id);
+            $validation = get_field('chasse_cache_statut_validation', $chasse_id);
 
         }
 

--- a/inc/chasse-functions.php
+++ b/inc/chasse-functions.php
@@ -54,8 +54,8 @@ function chasse_get_champs($chasse_id) {
         'date_fin' => get_field('chasse_infos_date_fin', $chasse_id),
         'illimitee' => get_field('chasse_infos_duree_illimitee', $chasse_id) ?? false,
         'nb_max' => get_field('chasse_infos_nb_max_gagants', $chasse_id) ?? 0,
-        'date_decouverte' => get_field('champs_caches_chasse_cache_date_decouverte', $chasse_id),
-        'current_stored_statut' => get_field('champs_caches_chasse_cache_statut', $chasse_id),
+        'date_decouverte' => get_field('chasse_cache_date_decouverte', $chasse_id),
+        'current_stored_statut' => get_field('chasse_cache_statut', $chasse_id),
     ];
 }
 
@@ -310,8 +310,8 @@ function peut_valider_chasse(int $chasse_id, int $user_id): bool
         return false;
     }
 
-    $statut_validation = get_field('champs_caches_chasse_cache_statut_validation', $chasse_id);
-    $statut_metier     = get_field('champs_caches_chasse_cache_statut', $chasse_id);
+    $statut_validation = get_field('chasse_cache_statut_validation', $chasse_id);
+    $statut_metier     = get_field('chasse_cache_statut', $chasse_id);
 
     if (!in_array($statut_validation ?? '', ['creation', 'correction'], true)) {
         return false;

--- a/inc/edition/edition-chasse.php
+++ b/inc/edition/edition-chasse.php
@@ -137,9 +137,9 @@ function creer_chasse_et_rediriger_si_appel()
   update_field('chasse_infos_date_fin', $in_two_years, $post_id);
   update_field('chasse_infos_duree_illimitee', false, $post_id);
 
-  update_field('champs_caches_chasse_cache_statut', 'revision', $post_id);
-  update_field('champs_caches_chasse_cache_statut_validation', 'creation', $post_id);
-  update_field('champs_caches_chasse_cache_organisateur', [$organisateur_id], $post_id);
+  update_field('chasse_cache_statut', 'revision', $post_id);
+  update_field('chasse_cache_statut_validation', 'creation', $post_id);
+  update_field('chasse_cache_organisateur', [$organisateur_id], $post_id);
 
   // 🚀 Redirection vers la prévisualisation frontale avec panneau ouvert
   $preview_url = add_query_arg('edition', 'open', get_preview_post_link($post_id));
@@ -411,7 +411,7 @@ function modifier_champ_chasse()
 
   // 🔹 Validation manuelle (par admin)
   if ($champ === 'champs_caches.chasse_cache_statut_validation' || $champ === 'chasse_cache_statut_validation') {
-    $ok = update_field('champs_caches_chasse_cache_statut_validation', sanitize_text_field($valeur), $post_id);
+    $ok = update_field('chasse_cache_statut_validation', sanitize_text_field($valeur), $post_id);
     if ($ok !== false) $champ_valide = true;
   }
 
@@ -477,10 +477,9 @@ function assigner_organisateur_a_chasse($post_id, $post)
   if (!empty($organisateur_id)) {
     $resultat = mettre_a_jour_relation_acf(
       $post_id,                       // ID du post (chasse)
-      'organisateur_chasse',          // Nom du champ relation
+      'chasse_cache_organisateur',    // Nom du champ relation
       $organisateur_id,               // ID du post cible (organisateur)
-      'field_67cfcba8c3bec',          // Clé ACF du champ
-      'champs_caches_'                // Groupe ACF (préfixe)
+      'field_67cfcba8c3bec'
     );
 
     // Vérification après mise à jour

--- a/inc/edition/edition-enigme.php
+++ b/inc/edition/edition-enigme.php
@@ -678,7 +678,7 @@ add_action('acf/save_post', function ($post_id) {
   // ✅ Ajoute l’ID de l’énigme à la relation "chasse_cache_enigmes"
   $success = modifier_relation_acf(
     $chasse_id,
-    'champs_caches_enigmes',
+    'chasse_cache_enigmes',
     $post_id,
     'field_67b740025aae0',
     'add'
@@ -693,10 +693,10 @@ add_action('acf/save_post', function ($post_id) {
 
 
 /**
- * 🧹 Nettoyer les relations ACF orphelines dans le champ `champs_caches_enigmes_associees`.
+ * 🧹 Nettoyer les relations ACF orphelines dans le champ `chasse_cache_enigmes`.
  *
  * Cette fonction parcourt toutes les chasses possédant des valeurs dans le champ ACF
- * `champs_caches_enigmes_associees`, et supprime les références à des énigmes qui ont été supprimées.
+ * `chasse_cache_enigmes`, et supprime les références à des énigmes qui ont été supprimées.
  *
  * ⚠️ Cette vérification est utile notamment lorsqu'on supprime une énigme manuellement
  * ou que la cohérence de la relation ACF est rompue.
@@ -715,7 +715,7 @@ function nettoyer_relations_orphelines()
   $chasses = $wpdb->get_results("
         SELECT post_id, meta_value 
         FROM {$wpdb->postmeta} 
-        WHERE meta_key = 'champs_caches_enigmes_associees'
+        WHERE meta_key = 'chasse_cache_enigmes'
     ");
 
   foreach ($chasses as $chasse) {
@@ -733,7 +733,7 @@ function nettoyer_relations_orphelines()
 
     // 🔥 Si on a supprimé des IDs, mettre à jour la base
     if (count($relations_nettoyees) !== count($relations)) {
-      update_post_meta($post_id, 'champs_caches_enigmes_associees', $relations_nettoyees);
+      update_post_meta($post_id, 'chasse_cache_enigmes', $relations_nettoyees);
       cat_debug("✅ Relations nettoyées pour la chasse ID {$post_id} : " . print_r($relations_nettoyees, true));
     }
   }
@@ -746,7 +746,7 @@ function nettoyer_relations_orphelines()
  * Si le post supprimé est de type `enigme`, elle effectue :
  *
  * 1. 🔄 La suppression de l’ID de l’énigme dans le champ relation ACF
- *    `champs_caches_enigmes_associees` de la chasse associée, via `modifier_relation_acf()`.
+ *    `chasse_cache_enigmes` de la chasse associée, via `modifier_relation_acf()`.
  *
  * 2. 🧹 Un nettoyage global des champs relationnels dans toutes les chasses,
  *    pour supprimer les références à des énigmes qui n’existent plus,
@@ -769,8 +769,8 @@ add_action('before_delete_post', function ($post_id) {
   }
 
   // 🔹 Supprimer proprement la relation avec l’énigme supprimée
-  $acf_key = 'field_67b740025aae0'; // Clé exacte du champ `champs_caches_enigmes_associees`
-  modifier_relation_acf($chasse_id, 'champs_caches_enigmes_associees', $post_id, $acf_key, 'remove');
+  $acf_key = 'field_67b740025aae0'; // Clé exacte du champ `chasse_cache_enigmes`
+  modifier_relation_acf($chasse_id, 'chasse_cache_enigmes', $post_id, $acf_key, 'remove');
 
   // 🔹 Nettoyer les relations orphelines (toutes les chasses)
   nettoyer_relations_orphelines();

--- a/inc/edition/edition-organisateur.php
+++ b/inc/edition/edition-organisateur.php
@@ -311,7 +311,7 @@ function rediriger_selon_etat_organisateur()
   $query = get_chasses_de_organisateur($organisateur_id);
   if ($query && $query->have_posts()) {
     foreach ($query->posts as $chasse) {
-      $statut_validation = get_field('champs_caches_chasse_cache_statut_validation', $chasse->ID);
+      $statut_validation = get_field('chasse_cache_statut_validation', $chasse->ID);
       if ($statut_validation !== 'en_attente') {
         $has_chasse_non_attente = true;
         break;

--- a/inc/organisateur-functions.php
+++ b/inc/organisateur-functions.php
@@ -372,7 +372,7 @@ function get_cta_devenir_organisateur(?int $user_id = null): array
         $query = get_chasses_de_organisateur($organisateur_id);
         if ($query && $query->have_posts()) {
             foreach ($query->posts as $chasse) {
-                $statut_validation = get_field('champs_caches_chasse_cache_statut_validation', $chasse->ID);
+                $statut_validation = get_field('chasse_cache_statut_validation', $chasse->ID);
                 if ($statut_validation === 'en_attente') {
                     $has_pending_chasse = true;
                     break;

--- a/inc/relations-functions.php
+++ b/inc/relations-functions.php
@@ -63,7 +63,7 @@ function get_organisateur_chasse($chasse_id)
 function get_organisateur_from_chasse($chasse_id)
 {
   // ✅ Lecture directe
-  $relation = get_field('champs_caches_chasse_cache_organisateur', $chasse_id);
+  $relation = get_field('chasse_cache_organisateur', $chasse_id);
 
   if (!empty($relation)) {
 
@@ -219,12 +219,12 @@ function organisateur_a_des_chasses($organisateur_id)
     'meta_query'     => [
       'relation' => 'AND',
       [
-        'key'     => 'champs_caches_chasse_cache_organisateur',
+        'key'     => 'chasse_cache_organisateur',
         'value'   => '"' . $organisateur_id . '"',
         'compare' => 'LIKE'
       ],
       [
-        'key'     => 'champs_caches_chasse_cache_statut_validation',
+        'key'     => 'chasse_cache_statut_validation',
         'value'   => 'banni',
         'compare' => '!='
       ]
@@ -248,7 +248,7 @@ function get_chasses_de_organisateur($organisateur_id)
     'post_status'    => ['publish', 'pending'], // Inclure les chasses en attente
     'meta_query'     => [
       [
-        'key'     => 'champs_caches_chasse_cache_organisateur', // Champ correct
+        'key'     => 'chasse_cache_organisateur', // Champ correct
         'value'   => '"' . strval($organisateur_id) . '"', // Recherche dans le tableau sérialisé
         'compare' => 'LIKE'
       ]
@@ -280,8 +280,8 @@ function get_chasses_en_creation($organisateur_id)
   $filtrees = array_filter($chasses, function ($post) {
     $id = $post->ID;
     $statut_wp = get_post_status($id);
-    $statut_validation = get_field('champs_caches_chasse_cache_statut_validation', $id);
-    $statut_metier = get_field('champs_caches_chasse_cache_statut', $id);
+    $statut_validation = get_field('chasse_cache_statut_validation', $id);
+    $statut_metier = get_field('chasse_cache_statut', $id);
 
     error_log("🧪 #$id | statut=$statut_wp | validation=$statut_validation | metier=$statut_metier");
 
@@ -321,7 +321,7 @@ function recuperer_enigmes_associees(int $chasse_id): array
     return [];
   }
 
-  $liste_brute = get_field('champs_caches_chasse_cache_enigmes', $chasse_id) ?? [];
+  $liste_brute = get_field('chasse_cache_enigmes', $chasse_id) ?? [];
 
   // Extraction des IDs (objet ou int)
   $ids = [];
@@ -696,8 +696,7 @@ function synchroniser_relations_cache_enigmes($chasse_id): bool
       $chasse_id,
       'chasse_cache_enigmes',
       $enigme_id,
-      'field_67b740025aae0',
-      'champs_caches_'
+      'field_67b740025aae0'
     );
 
     if (!$ok) {
@@ -740,12 +739,12 @@ function forcer_relation_enigme_dans_chasse_si_absente(int $enigme_id): void
     return;
   }
 
-  $liste = is_array(get_field('champs_caches_chasse_cache_enigmes', $chasse_id) ?? null) ? array_map('intval', get_field('champs_caches_chasse_cache_enigmes', $chasse_id)) : [];
+  $liste = is_array(get_field('chasse_cache_enigmes', $chasse_id) ?? null) ? array_map('intval', get_field('chasse_cache_enigmes', $chasse_id)) : [];
 
   if (!in_array($enigme_id, $liste, true)) {
     $ok = modifier_relation_acf(
       $chasse_id,
-      'champs_caches_chasse_cache_enigmes',
+      'chasse_cache_enigmes',
       $enigme_id,
       'field_67b740025aae0',
       'add'

--- a/inc/statut-functions.php
+++ b/inc/statut-functions.php
@@ -315,7 +315,7 @@ function traiter_statut_enigme(int $enigme_id, ?int $user_id = null): array
     }
 
     // ✅ Chasse terminée = accès libre à toutes les énigmes
-    $statut_chasse = get_field('champs_caches_chasse_cache_statut', $chasse_id);
+    $statut_chasse = get_field('chasse_cache_statut', $chasse_id);
     if ($statut_chasse === 'termine') {
         return [
             'etat' => 'terminee',
@@ -430,7 +430,7 @@ function enigme_mettre_a_jour_etat_systeme(int $enigme_id, bool $mettre_a_jour =
         $etat = 'bloquee_chasse';
         cat_debug("🧩 #$enigme_id → bloquee_chasse (aucune chasse valide liée)");
     } else {
-        $statut_chasse = $statut_chasse_forcé ?? get_field('champs_caches_chasse_cache_statut', $chasse_id);
+        $statut_chasse = $statut_chasse_forcé ?? get_field('chasse_cache_statut', $chasse_id);
         cat_debug("🧩 #$enigme_id → chasse #$chasse_id statut = $statut_chasse");
 
         if (!in_array($statut_chasse, ['en_cours', 'payante', 'termine'], true)) {
@@ -741,7 +741,7 @@ function verifier_ou_recalculer_statut_chasse($chasse_id): void
     $chasses_traitees[] = $chasse_id;
 
 
-    $statut = get_field('champs_caches_chasse_cache_statut', $chasse_id);
+    $statut = get_field('chasse_cache_statut', $chasse_id);
 
     // Si le statut est manquant ou invalide, on le recalcule
     $statuts_valides = ['revision', 'a_venir', 'en_cours', 'payante', 'termine'];
@@ -777,9 +777,9 @@ function mettre_a_jour_statuts_chasse($chasse_id)
     if (get_post_type($chasse_id) !== 'chasse') return;
 
     $cache = [
-        'validation' => get_field('champs_caches_chasse_cache_statut_validation', $chasse_id),
-        'statut'     => get_field('champs_caches_chasse_cache_statut', $chasse_id),
-        'date'       => get_field('champs_caches_chasse_cache_date_decouverte', $chasse_id),
+        'validation' => get_field('chasse_cache_statut_validation', $chasse_id),
+        'statut'     => get_field('chasse_cache_statut', $chasse_id),
+        'date'       => get_field('chasse_cache_date_decouverte', $chasse_id),
     ];
 
     $carac = [
@@ -833,7 +833,7 @@ function mettre_a_jour_statuts_chasse($chasse_id)
         }
     }
 
-    update_field('champs_caches_chasse_cache_statut', $statut, $chasse_id);
+    update_field('chasse_cache_statut', $statut, $chasse_id);
 
     if (function_exists('synchroniser_cache_enigmes_chasse')) {
         synchroniser_cache_enigmes_chasse($chasse_id, true, true);
@@ -923,7 +923,7 @@ function recuperer_statut_chasse()
         wp_send_json_error('post_invalide');
     }
 
-    $statut = get_field('champs_caches_chasse_cache_statut', $post_id);
+    $statut = get_field('chasse_cache_statut', $post_id);
     if (!$statut) {
         wp_send_json_error('statut_indisponible');
     }
@@ -951,10 +951,10 @@ function forcer_statut_apres_acf($post_id, $nouvelle_validation = null)
     if (!is_numeric($post_id) || get_post_type($post_id) !== 'chasse') return;
 
     // Lecture et mise à jour facultative
-    $validation = get_field('champs_caches_chasse_cache_statut_validation', $post_id);
+    $validation = get_field('chasse_cache_statut_validation', $post_id);
 
     if ($nouvelle_validation !== null) {
-        update_field('champs_caches_chasse_cache_statut_validation', sanitize_text_field($nouvelle_validation), $post_id);
+        update_field('chasse_cache_statut_validation', sanitize_text_field($nouvelle_validation), $post_id);
         $validation = sanitize_text_field($nouvelle_validation);
     }
 
@@ -1022,7 +1022,7 @@ function forcer_statut_selon_validation_chasse($post_id, $post, $update)
     if (defined('DOING_AUTOSAVE') && DOING_AUTOSAVE) return;
     if (wp_is_post_revision($post_id)) return;
 
-    $validation = get_field('champs_caches_chasse_cache_statut_validation', $post_id);
+    $validation = get_field('chasse_cache_statut_validation', $post_id);
     if (!$validation) return;
     $statut_wp = get_post_status($post_id);
 

--- a/templates/page-traitement-validation-chasse.php
+++ b/templates/page-traitement-validation-chasse.php
@@ -35,7 +35,7 @@ if (!peut_valider_chasse($chasse_id, $user_id)) {
 forcer_statut_apres_acf($chasse_id, 'en_attente');
 
 // Met à jour le statut métier pour refléter l'attente de validation
-update_field('champs_caches_chasse_cache_statut', 'en_attente', $chasse_id);
+update_field('chasse_cache_statut', 'en_attente', $chasse_id);
 
 wp_redirect(add_query_arg('validation_demandee', '1', get_permalink($chasse_id)));
 exit;


### PR DESCRIPTION
## Summary
- strip `champs_caches_` prefix from meta keys
- update relation helper usage to use new field names

## Testing
- `npm test` *(fails: package.json missing)*
- `./vendor/bin/phpunit tests` *(fails: phpunit not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d6b38fda483329d65b0d2c3deb00e