### PR TITLE
Update tests for flat mock fields

### DIFF
--- a/tests/AccessFunctionsTest.php
+++ b/tests/AccessFunctionsTest.php
@@ -84,7 +84,7 @@ class AccessFunctionsTest extends TestCase
         $mock_fields[200]['utilisateurs_associes'] = [3];
 
         $mock_posts[201] = ['post_type' => 'chasse'];
-        $mock_fields[201]['champs_caches'] = ['chasse_cache_organisateur' => 200];
+        $mock_fields[201]['chasse_cache_organisateur'] = 200;
 
         $this->assertTrue(utilisateur_peut_modifier_post(201));
     }
@@ -100,7 +100,7 @@ class AccessFunctionsTest extends TestCase
         $mock_fields[300]['utilisateurs_associes'] = [4];
 
         $mock_posts[301] = ['post_type' => 'chasse'];
-        $mock_fields[301]['champs_caches'] = ['chasse_cache_organisateur' => 300];
+        $mock_fields[301]['chasse_cache_organisateur'] = 300;
 
         $mock_posts[302] = ['post_type' => 'enigme'];
         $mock_fields[302]['enigme_chasse_associee'] = 301;

--- a/tests/EditionCoreGroupTest.php
+++ b/tests/EditionCoreGroupTest.php
@@ -38,7 +38,7 @@ class EditionCoreGroupTest extends TestCase
         );
 
         $this->assertTrue($result);
-        $this->assertSame('2025-06-01 00:00:00', $mock_fields[$post_id]['caracteristiques']['chasse_infos_date_debut']);
+        $this->assertSame('2025-06-01 00:00:00', $mock_fields[$post_id]['chasse_infos_date_debut']);
     }
 
     public function test_grouped_updates_store_values()
@@ -72,7 +72,7 @@ class EditionCoreGroupTest extends TestCase
         $result = mettre_a_jour_sous_champ_group($post_id, 'infos', '', $values);
 
         $this->assertTrue($result);
-        $this->assertSame('Test', $mock_fields[$post_id]['infos']['infos_titre']);
-        $this->assertSame('2025-05-01 10:30:00', $mock_fields[$post_id]['infos']['infos_date']);
+        $this->assertSame('Test', $mock_fields[$post_id]['infos_titre']);
+        $this->assertSame('2025-05-01 10:30:00', $mock_fields[$post_id]['infos_date']);
     }
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -45,7 +45,9 @@ if (!function_exists('update_field')) {
                     $converted[$name] = $value[$key];
                 }
             }
-            $mock_fields[$post_id][$group['name']] = $converted;
+            foreach ($converted as $name => $val) {
+                $mock_fields[$post_id][$name] = $val;
+            }
         } else {
             $mock_fields[$post_id][$selector] = $value;
         }
@@ -144,8 +146,15 @@ if (!function_exists('get_field')) {
             }
         }
 
-        if ($group && isset($mock_fields[$post_id][$group['name']])) {
-            return $mock_fields[$post_id][$group['name']];
+        if ($group && isset($group['sub_fields'])) {
+            $values = [];
+            foreach ($group['sub_fields'] as $sub) {
+                $name = $sub['name'];
+                if (array_key_exists($name, $mock_fields[$post_id] ?? [])) {
+                    $values[$name] = $mock_fields[$post_id][$name];
+                }
+            }
+            return $values ?: null;
         }
 
         return $mock_fields[$post_id][$key] ?? null;
@@ -163,11 +172,7 @@ if (!function_exists('recuperer_id_chasse_associee')) {
 }
 if (!function_exists('get_organisateur_from_chasse')) {
     function get_organisateur_from_chasse($chasse_id) {
-        $cache = get_field('champs_caches', $chasse_id);
-        if (!$cache || !isset($cache['chasse_cache_organisateur'])) {
-            return null;
-        }
-        $id = $cache['chasse_cache_organisateur'];
+        $id = get_field('chasse_cache_organisateur', $chasse_id);
         if (is_array($id)) {
             $id = reset($id);
         } elseif ($id instanceof WP_Post) {


### PR DESCRIPTION
## Summary
- store ACF mock fields with flat keys
- adapt AccessFunctionsTest and EditionCoreGroupTest to new structure

## Testing
- `./vendor/bin/phpunit -c tests/phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_685d6f0595848332b4c3b41d96f47f73