### PR TITLE
Update docs with flat ACF fields

### DIFF
--- a/notices/fields/cout-points.md
+++ b/notices/fields/cout-points.md
@@ -4,8 +4,8 @@ Ce document décrit la structure HTML, la logique JS et le traitement PHP pour l
 
 Actuellement utilisé pour :
 
-* `caracteristiques.chasse_infos_cout_points` (CPT `chasse`)
-* `enigme_tentative.enigme_tentative_cout_points` (CPT `enigme`)
+* `chasse_infos_cout_points` (CPT `chasse`)
+* `enigme_tentative_cout_points` (CPT `enigme`)
 
 ---
 
@@ -39,7 +39,7 @@ Actuellement utilisé pour :
 </li>
 ```
 
-> Remplacer `champ-cpt` et `xxx.yyy` par les bons identifiants selon le contexte (ex: `champ-chasse`, `caracteristiques.chasse_infos_cout_points`).
+> Remplacer `champ-cpt` et `xxx.yyy` par les bons identifiants selon le contexte (ex: `champ-chasse`, `chasse_infos_cout_points`).
 
 ---
 
@@ -104,14 +104,14 @@ document.addEventListener('DOMContentLoaded', initChampCoutPoints);
 
 ```js
 window.onCoutPointsUpdated = function (bloc, champ, valeur, postId, cpt) {
-  if (champ === 'caracteristiques.chasse_infos_cout_points') {
+  if (champ === 'chasse_infos_cout_points') {
     if (typeof mettreAJourAffichageCout === 'function') {
       mettreAJourAffichageCout(postId, valeur);
     }
   }
 
-  if (champ === 'enigme_tentative.enigme_tentative_cout_points') {
-    const champMaxBloc = document.querySelector('[data-champ="enigme_tentative.enigme_tentative_max"]');
+  if (champ === 'enigme_tentative_cout_points') {
+    const champMaxBloc = document.querySelector('[data-champ="enigme_tentative_max"]');
     const champMaxInput = champMaxBloc?.querySelector('.champ-input');
     const message = champMaxBloc?.querySelector('.message-tentatives');
 
@@ -119,7 +119,7 @@ window.onCoutPointsUpdated = function (bloc, champ, valeur, postId, cpt) {
       if (valeur === 0) {
         champMaxInput.value = 5;
         champMaxInput.max = 5;
-        modifierChampSimple('enigme_tentative.enigme_tentative_max', 5, postId, cpt);
+        modifierChampSimple('enigme_tentative_max', 5, postId, cpt);
       } else {
         champMaxInput.removeAttribute('max');
       }
@@ -141,8 +141,8 @@ window.onCoutPointsUpdated = function (bloc, champ, valeur, postId, cpt) {
 ### Exemple `chasse` :
 
 ```php
-if ($champ === 'caracteristiques.chasse_infos_cout_points') {
-  $ok = mettre_a_jour_sous_champ_group($post_id, 'caracteristiques', 'chasse_infos_cout_points', (int) $valeur);
+if ($champ === 'chasse_infos_cout_points') {
+  $ok = update_field('chasse_infos_cout_points', (int) $valeur, $post_id);
   if ($ok) {
     $champ_valide = true;
     $doit_recalculer_statut = true;

--- a/notices/fields/date-edition.md
+++ b/notices/fields/date-edition.md
@@ -12,7 +12,7 @@ Ce document décrit les bonnes pratiques pour gérer un champ ACF de type `date`
 
 ```php
 <div class="champ-chasse champ-date-debut"
-     data-champ="caracteristiques.chasse_infos_date_debut"
+     data-champ="chasse_infos_date_debut"
      data-cpt="chasse"
      data-post-id="<?= esc_attr($post_id); ?>">
 
@@ -85,7 +85,7 @@ if ($champ === 'enigme_acces.date') {
     wp_send_json_error('⚠️ format_date_invalide');
   }
   $valeur .= ' 00:00:00'; // conversion Y-m-d -> Y-m-d H:i:s
-  $ok = mettre_a_jour_sous_champ_group($post_id, 'enigme_acces', 'enigme_acces_date', $valeur);
+  $ok = update_field('enigme_acces_date', $valeur, $post_id);
   if ($ok) wp_send_json_success([...]);
   wp_send_json_error('⚠️ echec_mise_a_jour_final');
 }
@@ -98,7 +98,7 @@ if ($champ === 'enigme_acces.date') {
 ```js
 window.onDateFieldUpdated = function(input, valeur) {
   const champ = input.closest('[data-champ]')?.dataset.champ;
-  if (champ === 'caracteristiques.chasse_infos_date_debut') {
+  if (champ === 'chasse_infos_date_debut') {
     const span = document.querySelector('.date-debut');
     if (span) span.textContent = formatDateFr(valeur);
   }

--- a/notices/global.md
+++ b/notices/global.md
@@ -570,7 +570,7 @@ L enregistrement se fait automatiquement à la saisie ou après délai (debounce
 En revanche, les champs obligatoires ou facultatifs sont masqués derrière un résumé. Ils s’ouvrent via un bouton ✏️ (stylo) et déclenchent un panneau latéral ou une édition inline avec affichage progressif (champ-affichage + champ-edition).
 <!-- Nombre de gagnants -->
 <li class="champ-chasse champ-nb-gagnants <?= empty($nb_max) ? 'champ-vide' : 'champ-rempli'; ?>"
-    data-champ="caracteristiques.chasse_infos_nb_max_gagants"
+    data-champ="chasse_infos_nb_max_gagants"
     data-cpt="chasse"
     data-post-id="<?= esc_attr($chasse_id); ?>">
 
@@ -589,7 +589,7 @@ En revanche, les champs obligatoires ou facultatifs sont masqués derrière un r
             id="nb-gagnants-illimite"
             name="nb-gagnants-illimite"
             <?= ($nb_max == 0 ? 'checked' : ''); ?>
-            data-champ="caracteristiques.chasse_infos_nb_max_gagants">
+            data-champ="chasse_infos_nb_max_gagants">
     <label for="nb-gagnants-illimite">Illimité</label>
   </div>
 
@@ -622,9 +622,9 @@ defined('ABSPATH') || exit;
 $chasse_id = $args['chasse_id'] ?? null;
 if (!$chasse_id || get_post_type($chasse_id) !== 'chasse') return;
 
-$caracteristiques = get_field('caracteristiques', $chasse_id);
-$texte_recompense = $caracteristiques['chasse_infos_recompense_texte'] ?? '';
-$valeur_recompense = $caracteristiques['chasse_infos_recompense_valeur'] ?? '';
+$texte_recompense = get_field('chasse_infos_recompense_texte', $chasse_id) ?: '';
+$valeur_recompense = get_field('chasse_infos_recompense_valeur', $chasse_id) ?: '';
+$titre_recompense = get_field('chasse_infos_recompense_titre', $chasse_id) ?: '';
 ?>
 
 
@@ -639,7 +639,7 @@ $valeur_recompense = $caracteristiques['chasse_infos_recompense_valeur'] ?? '';
     <div class="champ-wrapper" style="display: flex; flex-direction: column; gap: 20px;">
         
       <label for="champ-recompense-titre">Titre de la récompense <span class="champ-obligatoire">*</span></label>
-      <input id="champ-recompense-titre" type="text" maxlength="40" placeholder="Ex : Un papillon en cristal..." value="<?= esc_attr($caracteristiques['chasse_infos_recompense_titre'] ?? ''); ?>">
+      <input id="champ-recompense-titre" type="text" maxlength="40" placeholder="Ex : Un papillon en cristal..." value="<?= esc_attr($titre_recompense); ?>">
 
       <label for="champ-recompense-texte">Descripton de la récompense <span class="champ-obligatoire">*</span></label>
       <textarea id="champ-recompense-texte" rows="4" placeholder="Ex : Un coffret cadeau comprenant..."><?= esc_textarea(wp_strip_all_tags($texte_recompense)); ?></textarea>
@@ -800,9 +800,9 @@ Hook global onDateFieldUpdated() mis à jour pour gérer :
 
 enigme_acces.date
 
-caracteristiques.chasse_infos_date_debut
+chasse_infos_date_debut
 
-caracteristiques.chasse_infos_date_fin
+chasse_infos_date_fin
 
 👉 Préciser dans la section que :
 
@@ -1160,7 +1160,7 @@ Ne jamais déduire qu’un champ est un repeater ou un groupe sans analyse concr
 
 Chaque champ ciblé par un module JS (inline, conditionnel, panneau, etc.) doit contenir :
 
-- `data-champ="nom_acf_complet"` (ex : `caracteristiques.chasse_infos_cout_points`)
+- `data-champ="nom_acf_complet"` (ex : `chasse_infos_cout_points`)
 - `data-cpt="chasse"` (ou `organisateur`, `enigme`)
 - `data-post-id="ID"` (toujours requis pour AJAX)
 


### PR DESCRIPTION
## Summary
- update documentation to use flat field names
- remove references to deprecated `mettre_a_jour_sous_champ_group()`

## Testing
- `composer install` *(fails: command not found)*
- `vendor/bin/phpunit --configuration tests/phpunit.xml` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_685d72bc0fc483328c544233fc921c6e